### PR TITLE
feat: create provider entry point (main.go)

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/kosli-dev/terraform-provider-kosli/internal/provider"
+)
+
+// version is set via ldflags during the build process.
+// See GoReleaser configuration for details.
+var version = "dev"
+
+func main() {
+	var debug bool
+
+	flag.BoolVar(&debug, "debug", false, "set to true to run the provider with support for debuggers like delve")
+	flag.Parse()
+
+	opts := providerserver.ServeOpts{
+		Address: "registry.terraform.io/kosli-dev/kosli",
+		Debug:   debug,
+	}
+
+	err := providerserver.Serve(context.Background(), provider.New(version), opts)
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+}


### PR DESCRIPTION
## Summary

Creates the Terraform provider entry point that bootstraps the provider binary.

## Implementation

- Provider server initialization using terraform-plugin-framework
- Version handling via ldflags (set by GoReleaser during release)
- Debug flag support for development with debuggers
- Correct registry address: `registry.terraform.io/kosli-dev/kosli`

Binary builds successfully with both `go build` and `make build`.

Closes #13