### PR TITLE
build: add golangci-lint configuration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,65 @@
+# Schema: https://golangci-lint.run/jsonschema/golangci.jsonschema.json
+
+version: "2"
+
+run:
+  timeout: 5m
+  tests: true
+
+
+linters:
+  enable:
+    - errcheck      # Check for unchecked errors
+    - govet         # Go vet analysis
+    - ineffassign   # Detect ineffectual assignments
+    - misspell      # Spell checker
+    - staticcheck   # Static analysis
+    - unused        # Detect unused code
+
+  settings:
+    errcheck:
+      # Report errors in type assertions: `a := b.(MyStruct)`
+      check-type-assertions: false
+      # Report errors in blank assignments: `num, _ := strconv.Atoi(numStr)`
+      check-blank: false
+      # List of functions to exclude from checking
+      exclude-functions:
+        # Deferred Body.Close() errors are typically not actionable
+        - (io.Closer).Close
+        # Test helper writes don't need error checking in tests
+        - (io.Writer).Write
+        - (*os.File).Close
+
+    staticcheck:
+      checks: ["-ST1005"]  # Ignore capitalized error strings
+
+  exclusions:
+    rules:
+      # Exclude errcheck for test files entirely
+      - path: '.*_test\.go$'
+        linters:
+          - errcheck
+          - unused
+
+formatters:
+  enable:
+    - gofmt         # Check code formatting
+
+  settings:
+    gofmt:
+      # Simplify code: gofmt with `-s` option.
+      # Default: true
+      simplify: false
+
+      # Apply the rewrite rules to the source before reformatting.
+      # https://pkg.go.dev/cmd/gofmt
+      # Default: []
+      rewrite-rules:
+        - pattern: 'interface{}'
+          replacement: 'any'
+
+issues:
+  # Maximum issues count per one linter
+  max-issues-per-linter: 0
+  # Maximum count of issues with the same text
+  max-same-issues: 0

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -195,7 +195,7 @@ func TestGetConfigValue(t *testing.T) {
 			}
 
 			// Create a types.String value
-			var configValue interface{}
+			var configValue any
 			if tt.configVal != "" {
 				// We can't easily create types.String in tests without Terraform context
 				// This is tested implicitly through integration tests


### PR DESCRIPTION
Add comprehensive golangci-lint configuration following schema v2:
- Enable core linters: errcheck, govet, ineffassign, misspell, staticcheck, unused
- Configure errcheck to exclude common patterns (deferred Close calls)
- Exclude errcheck and unused linters for test files
- Enable gofmt formatter with interface{} → any rewrite rule
- Apply gofmt rewrite rule across codebase

closes #8 