### PR TITLE
feat: add acceptance tests for custom attestation type data source (#18)

### DIFF
--- a/internal/provider/data_source_custom_attestation_type_acc_test.go
+++ b/internal/provider/data_source_custom_attestation_type_acc_test.go
@@ -1,0 +1,264 @@
+package provider
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// TestAccCustomAttestationTypeDataSource_basic tests querying an existing custom attestation type
+func TestAccCustomAttestationTypeDataSource_basic(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test-ds")
+	resourceName := "kosli_custom_attestation_type.test"
+	dataSourceName := "data.kosli_custom_attestation_type.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCustomAttestationTypeDataSourceConfigBasic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Verify data source attributes match resource
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "schema", resourceName, "schema"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "jq_rules.#", resourceName, "jq_rules.#"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "jq_rules.0", resourceName, "jq_rules.0"),
+					// Verify archived is false
+					resource.TestCheckResourceAttr(dataSourceName, "archived", "false"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccCustomAttestationTypeDataSource_computedAttributes tests all computed attributes are populated
+func TestAccCustomAttestationTypeDataSource_computedAttributes(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test-ds")
+	resourceName := "kosli_custom_attestation_type.test"
+	dataSourceName := "data.kosli_custom_attestation_type.test"
+	description := "Test attestation type for data source verification"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCustomAttestationTypeDataSourceConfigFull(rName, description),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Verify all computed attributes
+					resource.TestCheckResourceAttr(dataSourceName, "name", rName),
+					resource.TestCheckResourceAttr(dataSourceName, "description", description),
+					resource.TestCheckResourceAttrSet(dataSourceName, "schema"),
+					resource.TestCheckResourceAttr(dataSourceName, "jq_rules.#", "2"),
+					resource.TestCheckResourceAttr(dataSourceName, "jq_rules.0", ".coverage >= 80"),
+					resource.TestCheckResourceAttr(dataSourceName, "jq_rules.1", ".branch == \"main\" or .branch == \"develop\""),
+					resource.TestCheckResourceAttr(dataSourceName, "archived", "false"),
+					// Verify data source matches resource
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "schema", resourceName, "schema"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "jq_rules.#", resourceName, "jq_rules.#"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccCustomAttestationTypeDataSource_notFound tests error handling for non-existent attestation type
+func TestAccCustomAttestationTypeDataSource_notFound(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test-ds-notfound")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCustomAttestationTypeDataSourceConfigNotFound(rName),
+				ExpectError: regexp.MustCompile(`Could not read custom attestation type`),
+			},
+		},
+	})
+}
+
+// TestAccCustomAttestationTypeDataSource_archived tests querying archived attestation types
+func TestAccCustomAttestationTypeDataSource_archived(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test-ds-archived")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Create resource
+			{
+				Config: testAccCustomAttestationTypeDataSourceConfigArchived(rName, 1),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("kosli_custom_attestation_type.test", "name", rName),
+				),
+			},
+			// Step 2: Archive resource and query with data source
+			// Due to server limitation #4466, archived types return 400 error
+			// This test verifies the error is returned appropriately
+			{
+				Config:      testAccCustomAttestationTypeDataSourceConfigArchived(rName, 2),
+				ExpectError: regexp.MustCompile(`is archived|Could not read custom attestation type`),
+			},
+		},
+	})
+}
+
+// TestAccCustomAttestationTypeDataSource_integration tests using data source output as resource input
+func TestAccCustomAttestationTypeDataSource_integration(t *testing.T) {
+	sourceName := acctest.RandomWithPrefix("tf-acc-test-ds-source")
+	derivedName := acctest.RandomWithPrefix("tf-acc-test-ds-derived")
+	dataSourceName := "data.kosli_custom_attestation_type.source"
+	derivedResourceName := "kosli_custom_attestation_type.derived"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCustomAttestationTypeDataSourceConfigIntegration(sourceName, derivedName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Verify source resource and data source
+					resource.TestCheckResourceAttr(dataSourceName, "name", sourceName),
+					resource.TestCheckResourceAttrSet(dataSourceName, "schema"),
+					resource.TestCheckResourceAttr(dataSourceName, "jq_rules.#", "1"),
+					// Verify derived resource uses data source values
+					resource.TestCheckResourceAttr(derivedResourceName, "name", derivedName),
+					resource.TestCheckResourceAttr(derivedResourceName, "description", fmt.Sprintf("Derived from: %s", sourceName)),
+					// Verify schema and jq_rules match source
+					resource.TestCheckResourceAttrPair(derivedResourceName, "schema", dataSourceName, "schema"),
+					resource.TestCheckResourceAttrPair(derivedResourceName, "jq_rules.#", dataSourceName, "jq_rules.#"),
+					resource.TestCheckResourceAttrPair(derivedResourceName, "jq_rules.0", dataSourceName, "jq_rules.0"),
+				),
+			},
+		},
+	})
+}
+
+// testAccCustomAttestationTypeDataSourceConfigBasic returns basic config with resource and data source
+func testAccCustomAttestationTypeDataSourceConfigBasic(name string) string {
+	return fmt.Sprintf(`
+resource "kosli_custom_attestation_type" "test" {
+  name = %[1]q
+  schema = jsonencode({
+    type = "object"
+    properties = {
+      coverage = {
+        type = "number"
+      }
+    }
+  })
+  jq_rules = [".coverage >= 80"]
+}
+
+data "kosli_custom_attestation_type" "test" {
+  name = kosli_custom_attestation_type.test.name
+}
+`, name)
+}
+
+// testAccCustomAttestationTypeDataSourceConfigFull returns full config with all attributes
+func testAccCustomAttestationTypeDataSourceConfigFull(name, description string) string {
+	return fmt.Sprintf(`
+resource "kosli_custom_attestation_type" "test" {
+  name        = %[1]q
+  description = %[2]q
+  schema = jsonencode({
+    type = "object"
+    properties = {
+      coverage = {
+        type = "number"
+      }
+      branch = {
+        type = "string"
+      }
+    }
+    required = ["coverage"]
+  })
+  jq_rules = [
+    ".coverage >= 80",
+    ".branch == \"main\" or .branch == \"develop\""
+  ]
+}
+
+data "kosli_custom_attestation_type" "test" {
+  name = kosli_custom_attestation_type.test.name
+}
+`, name, description)
+}
+
+// testAccCustomAttestationTypeDataSourceConfigNotFound returns config querying non-existent type
+func testAccCustomAttestationTypeDataSourceConfigNotFound(name string) string {
+	return fmt.Sprintf(`
+data "kosli_custom_attestation_type" "test" {
+  name = %[1]q
+}
+`, name)
+}
+
+// testAccCustomAttestationTypeDataSourceConfigArchived returns config for archived type test
+func testAccCustomAttestationTypeDataSourceConfigArchived(name string, step int) string {
+	if step == 1 {
+		// Step 1: Create resource
+		return fmt.Sprintf(`
+resource "kosli_custom_attestation_type" "test" {
+  name = %[1]q
+  schema = jsonencode({
+    type = "object"
+    properties = {
+      coverage = {
+        type = "number"
+      }
+    }
+  })
+  jq_rules = [".coverage >= 80"]
+}
+`, name)
+	}
+
+	// Step 2: Archive resource (remove it) and query with data source
+	return fmt.Sprintf(`
+data "kosli_custom_attestation_type" "test" {
+  name = %[1]q
+}
+`, name)
+}
+
+// testAccCustomAttestationTypeDataSourceConfigIntegration returns config for integration test
+func testAccCustomAttestationTypeDataSourceConfigIntegration(sourceName, derivedName string) string {
+	return fmt.Sprintf(`
+# First resource
+resource "kosli_custom_attestation_type" "source" {
+  name        = %[1]q
+  description = "Source attestation type"
+  schema = jsonencode({
+    type = "object"
+    properties = {
+      coverage = {
+        type = "number"
+      }
+    }
+  })
+  jq_rules = [".coverage >= 80"]
+}
+
+# Data source queries first resource
+data "kosli_custom_attestation_type" "source" {
+  name = kosli_custom_attestation_type.source.name
+}
+
+# Second resource uses data from first (via data source)
+resource "kosli_custom_attestation_type" "derived" {
+  name        = %[2]q
+  description = "Derived from: ${data.kosli_custom_attestation_type.source.name}"
+  schema      = data.kosli_custom_attestation_type.source.schema
+  jq_rules    = data.kosli_custom_attestation_type.source.jq_rules
+}
+`, sourceName, derivedName)
+}


### PR DESCRIPTION
## Summary

This PR adds comprehensive acceptance tests for the `kosli_custom_attestation_type` data source to verify end-to-end functionality against the real Kosli API in the `terraform-test` organization.

Closes #18

## Changes

### New Test File: `internal/provider/data_source_custom_attestation_type_acc_test.go`

Implements 5 acceptance test functions:

1. **TestAccCustomAttestationTypeDataSource_basic** - Tests querying an existing custom attestation type and verifying basic attributes match between data source and resource
2. **TestAccCustomAttestationTypeDataSource_computedAttributes** - Verifies all computed attributes (name, description, schema, jq_rules, archived) are populated correctly
3. **TestAccCustomAttestationTypeDataSource_notFound** - Tests error handling when querying a non-existent attestation type
4. **TestAccCustomAttestationTypeDataSource_archived** - Tests behavior when querying archived types (expects error due to server limitation #4466)
5. **TestAccCustomAttestationTypeDataSource_integration** - Tests using data source output as input to another resource (real-world usage pattern)

Each test includes:
- Unique random names using `tf-acc-test-ds` prefix
- Config helper functions to generate HCL
- Comprehensive checks using `resource.TestCheckResourceAttrPair()` and `resource.TestCheckResourceAttr()`

### Makefile Refactoring

- Extracted environment variable checks into reusable `check-testacc-env` prerequisite target
- Added `testacc-custom-attestation-type-datasource` target to run data source tests specifically
- Made all acceptance test targets depend on `check-testacc-env` to eliminate duplication
- Updated help text to include new target

## Test Coverage

All 5 test scenarios are covered:
- ✅ Basic data source read and attribute matching
- ✅ All computed attributes populated correctly
- ✅ Error handling for non-existent resources
- ✅ Archived type handling (server limitation #4466)
- ✅ Integration pattern demonstrating real-world usage

## Testing

Run data source acceptance tests with:
```bash
export KOSLI_API_TOKEN="your-token"
export KOSLI_ORG="terraform-test"
make testacc-custom-attestation-type-datasource
```

Or run all acceptance tests:
```bash
make testacc
```

Tests will automatically run in CI on push to main.

## Notes

- Tests reuse existing `testAccPreCheck` and `testAccProtoV6ProviderFactories` from issue #17
- Server limitation #4466: Archived types return 400 "is archived" error instead of 404, so the archived test expects an error
- Tests use unique naming to avoid conflicts with resource acceptance tests
