### PR TITLE
refactor: remove manual workflow dispatch trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
   push:
     tags:
       - 'v*.*.*'
-  workflow_dispatch:
 
 permissions:
   contents: write

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -409,12 +409,6 @@ Before creating a release, ensure the following secrets are configured in the re
    - GPG signatures
    - Auto-generated changelog
 
-#### Manual Workflow Trigger
-
-The release workflow can also be triggered manually from the GitHub Actions UI for testing purposes:
-1. Navigate to **Actions** → **Release** workflow
-2. Click **Run workflow**
-3. Select the branch and click **Run workflow**
 
 ### Conventional Commits & Release Notes
 


### PR DESCRIPTION
Simplify release workflow to only trigger on version tags. Manual dispatch is unnecessary since releases should only be created from tagged versions.

To test the workflow, create a test tag (e.g., v0.0.1-test).