### PR TITLE
fix: update data source acceptance tests for included_environments API fix

### DIFF
--- a/internal/provider/data_source_logical_environment_acc_test.go
+++ b/internal/provider/data_source_logical_environment_acc_test.go
@@ -28,8 +28,8 @@ func TestAccLogicalEnvironmentDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "type", resourceName, "type"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
-					// NOTE: API limitation - included_environments is not returned by GET endpoint
-					resource.TestCheckResourceAttr(dataSourceName, "included_environments.#", "0"),
+					// Verify included_environments is correctly returned by API
+					resource.TestCheckResourceAttr(dataSourceName, "included_environments.#", "2"),
 					// Verify timestamp field is populated
 					resource.TestCheckResourceAttrSet(dataSourceName, "last_modified_at"),
 				),
@@ -58,8 +58,8 @@ func TestAccLogicalEnvironmentDataSource_computedAttributes(t *testing.T) {
 					resource.TestCheckResourceAttr(dataSourceName, "name", rName),
 					resource.TestCheckResourceAttr(dataSourceName, "type", "logical"),
 					resource.TestCheckResourceAttr(dataSourceName, "description", description),
-					// NOTE: API limitation - included_environments is not returned by GET endpoint
-					resource.TestCheckResourceAttr(dataSourceName, "included_environments.#", "0"),
+					// Verify included_environments is correctly returned by API
+					resource.TestCheckResourceAttr(dataSourceName, "included_environments.#", "2"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "last_modified_at"),
 					// Verify data source matches resource
 					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
@@ -142,8 +142,8 @@ func TestAccLogicalEnvironmentDataSource_nullDescription(t *testing.T) {
 					resource.TestCheckResourceAttr(dataSourceName, "name", rName),
 					resource.TestCheckResourceAttr(dataSourceName, "type", "logical"),
 					resource.TestCheckNoResourceAttr(dataSourceName, "description"),
-					// NOTE: API limitation - included_environments is not returned by GET endpoint
-					resource.TestCheckResourceAttr(dataSourceName, "included_environments.#", "0"),
+					// Verify included_environments is correctly returned by API
+					resource.TestCheckResourceAttr(dataSourceName, "included_environments.#", "2"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "last_modified_at"),
 				),
 			},
@@ -171,8 +171,8 @@ func TestAccLogicalEnvironmentDataSource_integration(t *testing.T) {
 					// Verify source resource and data source
 					resource.TestCheckResourceAttr(dataSourceName, "name", sourceName),
 					resource.TestCheckResourceAttr(dataSourceName, "type", "logical"),
-					// NOTE: API limitation - included_environments is not returned by GET endpoint
-					resource.TestCheckResourceAttr(dataSourceName, "included_environments.#", "0"),
+					// Verify included_environments is correctly returned by API
+					resource.TestCheckResourceAttr(dataSourceName, "included_environments.#", "2"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "last_modified_at"),
 					// Verify derived resource uses data source description
 					resource.TestCheckResourceAttr(derivedResourceName, "name", derivedName),


### PR DESCRIPTION
## Summary

Fixes acceptance tests that were failing on main branch after the Kosli API was updated to return `included_environments` in GET responses for logical environments (server issue #4647).

## Changes

- Updated 4 data source acceptance tests to expect the correct number of included environments
- Changed tests that create 2 environments from expecting "0" to "2"
- Kept `TestAccLogicalEnvironmentDataSource_emptyIncludedEnvironments` expecting "0" (intentional empty list)
- Updated comments to reflect that the API now returns this field correctly

## Test Results

✅ All 7 logical environment data source acceptance tests now pass
✅ All 7 logical environment resource acceptance tests pass
✅ Full acceptance test suite passes (31 tests)

## Related Issues

Related to #101 - This PR fixes the test failures on main that were preventing the #101 changes from being merged cleanly.