### PR TITLE
ci: skip claude review for dependabot and bot PRs

### DIFF
--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -46,8 +46,7 @@ jobs:
     # Only run on opened and synchronize (new commits), and skip bot/dependabot PRs
     if: |
       (github.event.action == 'opened' || github.event.action == 'synchronize') &&
-      github.actor != 'dependabot[bot]' &&
-      github.actor_type != 'Bot'
+      github.event.pull_request.user.type != 'Bot'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Fixes failing Claude review job on Dependabot PRs by skipping the job when the PR author is a bot, using `github.event.pull_request.user.type != 'Bot'`.

Note: the Claude review job will fail on this PR itself — this is expected. `claude-code-action` validates that the workflow file is identical to the version on `main` as a security measure. It triggers any time the workflow file is modified in a PR.