### PR TITLE
ci: validate all examples in PR checks to match main pipeline

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -105,10 +105,19 @@ jobs:
       fail-fast: false
       matrix:
         example:
+          - examples/resources/kosli_action
           - examples/resources/kosli_custom_attestation_type
           - examples/resources/kosli_environment
+          - examples/resources/kosli_flow
+          - examples/resources/kosli_logical_environment
+          - examples/resources/kosli_policy
+          - examples/resources/kosli_policy_attachment
+          - examples/data-sources/kosli_action
           - examples/data-sources/kosli_custom_attestation_type
           - examples/data-sources/kosli_environment
+          - examples/data-sources/kosli_flow
+          - examples/data-sources/kosli_logical_environment
+          - examples/data-sources/kosli_policy
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
The PR CI workflow only validated 4 of the 13 examples that the main pipeline validates. This gap meant broken examples for newer resources (action, flow, logical_environment, policy, policy_attachment) could slip through PR review undetected, only failing after merge to main.

Expand the validate-examples matrix in ci.yaml to match main.yaml.