### PR TITLE
docs: update policy schema URL to docs.kosli.com

### DIFF
--- a/docs/resources/policy.md
+++ b/docs/resources/policy.md
@@ -31,7 +31,7 @@ terraform {
 resource "kosli_policy" "minimal" {
   name = "basic-requirements"
   content = <<-YAML
-    _schema: https://kosli.com/schemas/policy/environment/v1
+    _schema: https://docs.kosli.com/schemas/policy/v1
     artifacts:
       provenance:
         required: true
@@ -43,7 +43,7 @@ resource "kosli_policy" "production" {
   name        = "prod-requirements"
   description = "Compliance requirements for production environments"
   content     = <<-YAML
-    _schema: https://kosli.com/schemas/policy/environment/v1
+    _schema: https://docs.kosli.com/schemas/policy/v1
     artifacts:
       provenance:
         required: true
@@ -63,7 +63,7 @@ resource "kosli_policy" "production" {
 
 ### Required
 
-- `content` (String) YAML content of the policy, conforming to the Kosli policy schema (`_schema: https://kosli.com/schemas/policy/environment/v1`). Supports heredoc syntax for multi-line YAML. Updating this value creates a new policy version.
+- `content` (String) YAML content of the policy, conforming to the Kosli policy schema (`_schema: https://docs.kosli.com/schemas/policy/v1`). Supports heredoc syntax for multi-line YAML. Updating this value creates a new policy version.
 - `name` (String) Name of the policy. Must be unique within the organization. Changing this will force recreation of the resource.
 
 ### Optional

--- a/examples/resources/kosli_policy/resource.tf
+++ b/examples/resources/kosli_policy/resource.tf
@@ -10,7 +10,7 @@ terraform {
 resource "kosli_policy" "minimal" {
   name = "basic-requirements"
   content = <<-YAML
-    _schema: https://kosli.com/schemas/policy/environment/v1
+    _schema: https://docs.kosli.com/schemas/policy/v1
     artifacts:
       provenance:
         required: true
@@ -22,7 +22,7 @@ resource "kosli_policy" "production" {
   name        = "prod-requirements"
   description = "Compliance requirements for production environments"
   content     = <<-YAML
-    _schema: https://kosli.com/schemas/policy/environment/v1
+    _schema: https://docs.kosli.com/schemas/policy/v1
     artifacts:
       provenance:
         required: true

--- a/internal/provider/data_source_policy_test.go
+++ b/internal/provider/data_source_policy_test.go
@@ -94,7 +94,7 @@ func TestPolicyDataSourceModel_Structure(t *testing.T) {
 	model := policyDataSourceModel{
 		Name:          types.StringValue("prod-requirements"),
 		Description:   types.StringValue("Production policy"),
-		Content:       types.StringValue("_schema: https://kosli.com/schemas/policy/environment/v1\n"),
+		Content:       types.StringValue("_schema: https://docs.kosli.com/schemas/policy/v1\n"),
 		LatestVersion: types.Int64Value(3),
 		CreatedAt:     types.Float64Value(1633123457.123),
 	}

--- a/internal/provider/resource_policy.go
+++ b/internal/provider/resource_policy.go
@@ -68,7 +68,7 @@ func (r *policyResource) Schema(ctx context.Context, req resource.SchemaRequest,
 			},
 			"content": schema.StringAttribute{
 				MarkdownDescription: "YAML content of the policy, conforming to the Kosli policy schema " +
-					"(`_schema: https://kosli.com/schemas/policy/environment/v1`). " +
+					"(`_schema: https://docs.kosli.com/schemas/policy/v1`). " +
 					"Supports heredoc syntax for multi-line YAML. Updating this value creates a new policy version.",
 				Required: true,
 			},

--- a/internal/provider/resource_policy_acc_test.go
+++ b/internal/provider/resource_policy_acc_test.go
@@ -10,13 +10,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
-const testPolicyContent = `_schema: https://kosli.com/schemas/policy/environment/v1
+const testPolicyContent = `_schema: https://docs.kosli.com/schemas/policy/v1
 artifacts:
   provenance:
     required: true
 `
 
-const testPolicyContentUpdated = `_schema: https://kosli.com/schemas/policy/environment/v1
+const testPolicyContentUpdated = `_schema: https://docs.kosli.com/schemas/policy/v1
 artifacts:
   provenance:
     required: true

--- a/internal/provider/resource_policy_test.go
+++ b/internal/provider/resource_policy_test.go
@@ -125,7 +125,7 @@ func TestMapPolicyToModel_EmptyDescription(t *testing.T) {
 		Description: "",
 		CreatedAt:   1700000000.0,
 		Versions: []client.PolicyVersion{
-			{Version: 1, Content: "_schema: https://kosli.com/schemas/policy/environment/v1\n"},
+			{Version: 1, Content: "_schema: https://docs.kosli.com/schemas/policy/v1\n"},
 		},
 	}
 

--- a/pkg/client/policies_test.go
+++ b/pkg/client/policies_test.go
@@ -67,7 +67,7 @@ func TestCreatePolicy_Success(t *testing.T) {
 
 	err = c.CreatePolicy(context.Background(), &CreatePolicyRequest{
 		Name:    "test-policy",
-		Content: "_schema: https://kosli.com/schemas/policy/environment/v1\n",
+		Content: "_schema: https://docs.kosli.com/schemas/policy/v1\n",
 	})
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
@@ -102,7 +102,7 @@ func TestCreatePolicy_DefaultsTypeToEnv(t *testing.T) {
 	// Type is empty — should default to "env"
 	err = c.CreatePolicy(context.Background(), &CreatePolicyRequest{
 		Name:    "test-policy",
-		Content: "_schema: https://kosli.com/schemas/policy/environment/v1\n",
+		Content: "_schema: https://docs.kosli.com/schemas/policy/v1\n",
 	})
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
@@ -117,7 +117,7 @@ func TestGetPolicy_Success(t *testing.T) {
 		Versions: []PolicyVersion{
 			{
 				Version:   2,
-				Content:   "_schema: https://kosli.com/schemas/policy/environment/v1\n",
+				Content:   "_schema: https://docs.kosli.com/schemas/policy/v1\n",
 				CreatedAt: 1700000001.0,
 				CreatedBy: "user@example.com",
 			},


### PR DESCRIPTION
## Summary
- Migrated all `_schema` references from `kosli.com/schemas/policy/environment/v1` to `docs.kosli.com/schemas/policy/v1`
- Updated examples, generated docs, provider schema description, and all related tests