### PR TITLE
fix: use PATCH endpoint for environment updates

### DIFF
--- a/internal/provider/resource_environment.go
+++ b/internal/provider/resource_environment.go
@@ -187,7 +187,8 @@ func (r *environmentResource) Read(ctx context.Context, req resource.ReadRequest
 }
 
 // Update updates the resource and sets the updated Terraform state on success.
-// Per the API behavior, PUT is idempotent and updates the environment.
+// Uses PATCH /environments/{org}/{env_name} so that fields like description
+// can be cleared by sending empty values (see issue #122).
 func (r *environmentResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var data environmentResourceModel
 	var oldData environmentResourceModel
@@ -204,16 +205,15 @@ func (r *environmentResource) Update(ctx context.Context, req resource.UpdateReq
 		return
 	}
 
-	// Create API request (PUT is idempotent)
-	createReq := &client.CreateEnvironmentRequest{
-		Name:           data.Name.ValueString(),
-		Type:           data.Type.ValueString(),
-		Description:    data.Description.ValueString(),
-		IncludeScaling: data.IncludeScaling.ValueBool(),
+	description := data.Description.ValueString()
+	includeScaling := data.IncludeScaling.ValueBool()
+	updateReq := &client.UpdateEnvironmentRequest{
+		Description:    &description,
+		IncludeScaling: &includeScaling,
 	}
 
 	// Call API to update the environment
-	if err := r.client.CreateEnvironment(ctx, createReq); err != nil {
+	if err := r.client.UpdateEnvironment(ctx, data.Name.ValueString(), updateReq); err != nil {
 		resp.Diagnostics.AddError(
 			"Error Updating Environment",
 			fmt.Sprintf("Could not update environment %q: %s", data.Name.ValueString(), err.Error()),

--- a/internal/provider/resource_environment_acc_test.go
+++ b/internal/provider/resource_environment_acc_test.go
@@ -178,6 +178,39 @@ func TestAccEnvironmentResource_types(t *testing.T) {
 	}
 }
 
+// TestAccEnvironmentResource_clearDescription verifies that the description can
+// be removed from an existing environment by deleting the attribute. Regression
+// test for issue #122 — relies on the PATCH endpoint accepting an empty
+// description, which the legacy PUT endpoint silently ignored.
+func TestAccEnvironmentResource_clearDescription(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "kosli_environment.test"
+	description := "Initial description"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Create with a description
+			{
+				Config: testAccEnvironmentResourceConfigFull(rName, description),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", description),
+				),
+			},
+			// Step 2: Remove the description attribute - should clear it
+			{
+				Config: testAccEnvironmentResourceConfigNoDescription(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckNoResourceAttr(resourceName, "description"),
+				),
+			},
+		},
+	})
+}
+
 // TestAccEnvironmentResource_optionalDescription tests creating resource without description
 func TestAccEnvironmentResource_optionalDescription(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
@@ -219,6 +252,18 @@ resource "kosli_environment" "test" {
   include_scaling = true
 }
 `, name, description)
+}
+
+// testAccEnvironmentResourceConfigNoDescription returns configuration matching
+// testAccEnvironmentResourceConfigFull but without the description attribute.
+func testAccEnvironmentResourceConfigNoDescription(name string) string {
+	return fmt.Sprintf(`
+resource "kosli_environment" "test" {
+  name            = %[1]q
+  type            = "ECS"
+  include_scaling = true
+}
+`, name)
 }
 
 // testAccEnvironmentResourceConfigUpdate returns updated configuration

--- a/internal/provider/resource_logical_environment.go
+++ b/internal/provider/resource_logical_environment.go
@@ -205,7 +205,8 @@ func (r *logicalEnvironmentResource) Read(ctx context.Context, req resource.Read
 }
 
 // Update updates the resource and sets the updated Terraform state on success.
-// Per the API behavior, PUT is idempotent and updates the environment.
+// Uses PATCH /environments/{org}/{env_name} so that fields like description
+// can be cleared by sending empty values (see issue #122).
 func (r *logicalEnvironmentResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var data logicalEnvironmentResourceModel
 	var oldData logicalEnvironmentResourceModel
@@ -222,23 +223,23 @@ func (r *logicalEnvironmentResource) Update(ctx context.Context, req resource.Up
 		return
 	}
 
-	// Extract included_environments from types.List to []string
-	var includedEnvironments []string
+	// Extract included_environments from types.List to []string. Always send a
+	// non-nil slice for logical environments so the field is included in the
+	// PATCH body (an empty list is still a valid logical-environment update).
+	includedEnvironments := []string{}
 	resp.Diagnostics.Append(data.IncludedEnvironments.ElementsAs(ctx, &includedEnvironments, false)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	// Create API request (PUT is idempotent)
-	createReq := &client.CreateEnvironmentRequest{
-		Name:                 data.Name.ValueString(),
-		Type:                 "logical",
-		Description:          data.Description.ValueString(),
+	description := data.Description.ValueString()
+	updateReq := &client.UpdateEnvironmentRequest{
+		Description:          &description,
 		IncludedEnvironments: includedEnvironments,
 	}
 
 	// Call API to update the environment
-	if err := r.client.CreateEnvironment(ctx, createReq); err != nil {
+	if err := r.client.UpdateEnvironment(ctx, data.Name.ValueString(), updateReq); err != nil {
 		resp.Diagnostics.AddError(
 			"Error Updating Logical Environment",
 			fmt.Sprintf("Could not update logical environment %q: %s", data.Name.ValueString(), err.Error()),

--- a/internal/provider/resource_logical_environment_acc_test.go
+++ b/internal/provider/resource_logical_environment_acc_test.go
@@ -196,6 +196,40 @@ func TestAccLogicalEnvironmentResource_emptyList(t *testing.T) {
 }
 
 // TestAccLogicalEnvironmentResource_optionalDescription tests creating resource without description
+// TestAccLogicalEnvironmentResource_clearDescription is the regression test
+// for issue #122 against the logical-environment resource: once a description
+// is set, removing the attribute should clear it (relies on the PATCH endpoint).
+func TestAccLogicalEnvironmentResource_clearDescription(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test-logical")
+	envName1 := acctest.RandomWithPrefix("tf-acc-test-env1")
+	envName2 := acctest.RandomWithPrefix("tf-acc-test-env2")
+	resourceName := "kosli_logical_environment.test"
+	description := "Initial description"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Create with a description
+			{
+				Config: testAccLogicalEnvironmentResourceConfigFull(rName, envName1, envName2, description),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", description),
+				),
+			},
+			// Step 2: Remove the description attribute - should clear it
+			{
+				Config: testAccLogicalEnvironmentResourceConfigBasic(rName, envName1, envName2),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckNoResourceAttr(resourceName, "description"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccLogicalEnvironmentResource_optionalDescription(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test-logical")
 	envName1 := acctest.RandomWithPrefix("tf-acc-test-env1")

--- a/pkg/client/environments.go
+++ b/pkg/client/environments.go
@@ -32,6 +32,21 @@ type CreateEnvironmentRequest struct {
 	Policies             []any    // policies to attach to the environment
 }
 
+// UpdateEnvironmentRequest represents the user-facing request format for updating
+// an existing environment via PATCH /api/v2/environments/{org}/{env_name}.
+//
+// Unlike CreateEnvironmentRequest, the PATCH endpoint does not accept Name or
+// Type (those are immutable) and "omitted fields are left unchanged". Pointer
+// fields are only sent when non-nil so callers can update individual fields
+// without disturbing others. To clear the description, set Description to a
+// non-nil pointer to an empty string ("") — the PATCH endpoint accepts that
+// (see issue #122).
+type UpdateEnvironmentRequest struct {
+	Description          *string  // nil to omit; pointer to "" to clear
+	IncludeScaling       *bool    // nil to omit (e.g. logical environments)
+	IncludedEnvironments []string // for logical environments only; nil to omit
+}
+
 // ListEnvironments retrieves all environments for the organization.
 func (c *Client) ListEnvironments(ctx context.Context) ([]Environment, error) {
 	// Build path: GET /api/v2/environments/{org}
@@ -91,6 +106,40 @@ func (c *Client) CreateEnvironment(ctx context.Context, req *CreateEnvironmentRe
 
 	// Call API
 	resp, err := c.Put(ctx, path, body)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	return nil
+}
+
+// UpdateEnvironment updates an existing environment using PATCH.
+//
+// Unlike CreateEnvironment (which uses PUT and silently ignores attempts to
+// clear the description by sending an empty string), this endpoint accepts
+// empty values and applies them — for example, an empty description will
+// clear the field. See issue #122 for context.
+func (c *Client) UpdateEnvironment(ctx context.Context, name string, req *UpdateEnvironmentRequest) error {
+	// Build path: PATCH /api/v2/environments/{org}/{env_name}
+	path := fmt.Sprintf("/environments/%s/%s", c.Organization(), name)
+
+	// Build request body. Only include optional fields when the caller
+	// provided them, so fields that don't apply to a given environment
+	// kind (e.g. include_scaling on a logical environment) are omitted.
+	body := map[string]any{}
+	if req.Description != nil {
+		body["description"] = *req.Description
+	}
+	if req.IncludeScaling != nil {
+		body["include_scaling"] = *req.IncludeScaling
+	}
+	if req.IncludedEnvironments != nil {
+		body["included_environments"] = req.IncludedEnvironments
+	}
+
+	// Call API
+	resp, err := c.Patch(ctx, path, body)
 	if err != nil {
 		return err
 	}

--- a/pkg/client/environments_test.go
+++ b/pkg/client/environments_test.go
@@ -183,10 +183,8 @@ func TestGetEnvironment_NotFound(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for archived environment, got nil")
 	}
-
-	// Verify error message contains archived information
-	if !strings.Contains(err.Error(), "404") {
-		t.Errorf("expected error to mention 404, got: %v", err)
+	if !IsNotFound(err) {
+		t.Errorf("expected IsNotFound to return true, got error: %v", err)
 	}
 }
 
@@ -310,7 +308,7 @@ func TestCreateEnvironment_Idempotent(t *testing.T) {
 		t.Fatalf("first call failed: %v", err)
 	}
 
-	// Second call (update) - should be idempotent
+	// Second identical call - PUT is idempotent and should also succeed
 	err = client.CreateEnvironment(context.Background(), req)
 	if err != nil {
 		t.Fatalf("second call failed: %v", err)
@@ -600,22 +598,21 @@ func TestCreateEnvironment_LogicalWithEmptyList(t *testing.T) {
 	}
 }
 
-// TestCreateEnvironment_LogicalUpdate tests updating included_environments
-func TestCreateEnvironment_LogicalUpdate(t *testing.T) {
+// TestUpdateEnvironment_LogicalChangedEnvironments tests updating
+// included_environments on a logical environment via PATCH.
+func TestUpdateEnvironment_LogicalChangedEnvironments(t *testing.T) {
 	callCount := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		callCount++
+		if r.Method != http.MethodPatch {
+			t.Errorf("call %d: expected PATCH, got %s", callCount, r.Method)
+		}
+
 		var body map[string]any
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 			t.Fatalf("failed to decode request body: %v", err)
 		}
 
-		// Verify type is logical
-		if body["type"] != "logical" {
-			t.Errorf("call %d: expected type 'logical', got %v", callCount, body["type"])
-		}
-
-		// Verify included_environments changes between calls
 		rawIncludedEnvs, ok := body["included_environments"]
 		if !ok {
 			t.Fatalf("call %d: expected 'included_environments' field in request body", callCount)
@@ -633,6 +630,10 @@ func TestCreateEnvironment_LogicalUpdate(t *testing.T) {
 				t.Errorf("call 2: expected 3 environments, got %d", len(includedEnvs))
 			}
 		}
+		// include_scaling must be omitted for logical environments
+		if _, exists := body["include_scaling"]; exists {
+			t.Errorf("call %d: expected include_scaling to be omitted for logical environment, got %v", callCount, body["include_scaling"])
+		}
 
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(`"OK"`))
@@ -647,23 +648,19 @@ func TestCreateEnvironment_LogicalUpdate(t *testing.T) {
 		t.Fatalf("failed to create client: %v", err)
 	}
 
-	// First call - create with 2 environments
-	req := &CreateEnvironmentRequest{
-		Name:                 "logical-env",
-		Type:                 "logical",
-		Description:          "Logical environment",
+	// First update with 2 environments
+	description := "Logical environment"
+	req := &UpdateEnvironmentRequest{
+		Description:          &description,
 		IncludedEnvironments: []string{"env1", "env2"},
-		Policies:             []any{},
 	}
-	err = client.CreateEnvironment(context.Background(), req)
-	if err != nil {
+	if err := client.UpdateEnvironment(context.Background(), "logical-env", req); err != nil {
 		t.Fatalf("first call failed: %v", err)
 	}
 
-	// Second call - update to 3 environments
+	// Second update with 3 environments
 	req.IncludedEnvironments = []string{"env1", "env2", "env3"}
-	err = client.CreateEnvironment(context.Background(), req)
-	if err != nil {
+	if err := client.UpdateEnvironment(context.Background(), "logical-env", req); err != nil {
 		t.Fatalf("second call failed: %v", err)
 	}
 
@@ -745,6 +742,255 @@ func TestListEnvironments_WithLogical(t *testing.T) {
 	}
 	if environments[1].IncludedEnvironments[0] != "production-k8s" {
 		t.Errorf("expected included environment 'production-k8s', got %s", environments[1].IncludedEnvironments[0])
+	}
+}
+
+// TestUpdateEnvironment_Success verifies PATCH method, path, and body structure
+func TestUpdateEnvironment_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Errorf("expected PATCH, got %s", r.Method)
+		}
+		if !strings.Contains(r.URL.Path, "/environments/test-org/production-k8s") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+
+		ct := r.Header.Get("Content-Type")
+		if !strings.Contains(ct, "application/json") {
+			t.Errorf("expected application/json, got %s", ct)
+		}
+
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+
+		if body["description"] != "Updated description" {
+			t.Errorf("expected description 'Updated description', got %v", body["description"])
+		}
+		if body["include_scaling"] != true {
+			t.Errorf("expected include_scaling true, got %v", body["include_scaling"])
+		}
+		// included_environments should be omitted for physical env updates
+		if _, exists := body["included_environments"]; exists {
+			t.Errorf("expected included_environments to be omitted, got %v", body["included_environments"])
+		}
+		// type and name should not be in the PATCH body (immutable)
+		if _, exists := body["type"]; exists {
+			t.Errorf("expected type not to be in PATCH body, got %v", body["type"])
+		}
+		if _, exists := body["name"]; exists {
+			t.Errorf("expected name not to be in PATCH body, got %v", body["name"])
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`"OK"`))
+	}))
+	defer server.Close()
+
+	client, err := NewClient("test-token", "test-org",
+		WithBaseURL(server.URL),
+		WithAPIPath(""),
+	)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	description := "Updated description"
+	includeScaling := true
+	req := &UpdateEnvironmentRequest{
+		Description:    &description,
+		IncludeScaling: &includeScaling,
+	}
+
+	if err := client.UpdateEnvironment(context.Background(), "production-k8s", req); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+// TestUpdateEnvironment_ClearDescription verifies that an empty description is
+// sent as an empty string (the whole point of the new PATCH endpoint - see #122).
+func TestUpdateEnvironment_ClearDescription(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+
+		desc, exists := body["description"]
+		if !exists {
+			t.Fatal("expected description field in PATCH body, got missing")
+		}
+		if desc != "" {
+			t.Errorf("expected empty description, got %v", desc)
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`"OK"`))
+	}))
+	defer server.Close()
+
+	client, err := NewClient("test-token", "test-org",
+		WithBaseURL(server.URL),
+		WithAPIPath(""),
+	)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	description := ""
+	includeScaling := false
+	req := &UpdateEnvironmentRequest{
+		Description:    &description,
+		IncludeScaling: &includeScaling,
+	}
+
+	if err := client.UpdateEnvironment(context.Background(), "production-k8s", req); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+// TestUpdateEnvironment_OmitsNilFields verifies that nil pointer fields are
+// omitted from the request body — for example, a scaling-only update should
+// not contain a "description" key, leaving the existing description unchanged.
+func TestUpdateEnvironment_OmitsNilFields(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		if _, exists := body["description"]; exists {
+			t.Errorf("expected description to be omitted, got %v", body["description"])
+		}
+		if _, exists := body["included_environments"]; exists {
+			t.Errorf("expected included_environments to be omitted, got %v", body["included_environments"])
+		}
+		if body["include_scaling"] != true {
+			t.Errorf("expected include_scaling true, got %v", body["include_scaling"])
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`"OK"`))
+	}))
+	defer server.Close()
+
+	client, err := NewClient("test-token", "test-org",
+		WithBaseURL(server.URL),
+		WithAPIPath(""),
+	)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	includeScaling := true
+	req := &UpdateEnvironmentRequest{
+		IncludeScaling: &includeScaling,
+	}
+
+	if err := client.UpdateEnvironment(context.Background(), "production-k8s", req); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+// TestUpdateEnvironment_LogicalIncludesEnvironments verifies that
+// included_environments is sent for logical environment updates and that
+// include_scaling is omitted (logical envs don't have scaling).
+func TestUpdateEnvironment_LogicalIncludesEnvironments(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Errorf("expected PATCH, got %s", r.Method)
+		}
+
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+
+		rawIncluded, exists := body["included_environments"]
+		if !exists {
+			t.Fatal("expected included_environments in PATCH body")
+		}
+		included, ok := rawIncluded.([]any)
+		if !ok {
+			t.Fatalf("expected included_environments to be an array, got %T", rawIncluded)
+		}
+		if len(included) != 2 || included[0] != "env1" || included[1] != "env2" {
+			t.Errorf("unexpected included_environments: %v", included)
+		}
+		// include_scaling does not apply to logical environments and must
+		// not be sent in the PATCH body.
+		if _, exists := body["include_scaling"]; exists {
+			t.Errorf("expected include_scaling to be omitted for logical environment, got %v", body["include_scaling"])
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`"OK"`))
+	}))
+	defer server.Close()
+
+	client, err := NewClient("test-token", "test-org",
+		WithBaseURL(server.URL),
+		WithAPIPath(""),
+	)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	description := "Logical update"
+	req := &UpdateEnvironmentRequest{
+		Description:          &description,
+		IncludedEnvironments: []string{"env1", "env2"},
+	}
+
+	if err := client.UpdateEnvironment(context.Background(), "logical-env", req); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+// TestUpdateEnvironment_ServerError verifies error handling on 4xx
+func TestUpdateEnvironment_ServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{"message": "Input payload validation failed"})
+	}))
+	defer server.Close()
+
+	client, err := NewClient("test-token", "test-org",
+		WithBaseURL(server.URL),
+		WithAPIPath(""),
+	)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	err = client.UpdateEnvironment(context.Background(), "test-env", &UpdateEnvironmentRequest{})
+	if err == nil {
+		t.Fatal("expected error on 400, got nil")
+	}
+}
+
+// TestUpdateEnvironment_NotFound verifies 404 is reported as IsNotFound.
+func TestUpdateEnvironment_NotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(map[string]string{"message": "Environment 'missing' not found"})
+	}))
+	defer server.Close()
+
+	client, err := NewClient("test-token", "test-org",
+		WithBaseURL(server.URL),
+		WithAPIPath(""),
+	)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	err = client.UpdateEnvironment(context.Background(), "missing", &UpdateEnvironmentRequest{})
+	if err == nil {
+		t.Fatal("expected error on 404, got nil")
+	}
+	if !IsNotFound(err) {
+		t.Errorf("expected IsNotFound to return true, got error: %v", err)
 	}
 }
 


### PR DESCRIPTION
Fixes: #122

Switch the environment and logical-environment Update flows from the legacy PUT endpoint to PATCH /api/v2/environments/{org}/{env_name}. The PUT endpoint silently ignored description="" and rejected description=null, leaving Terraform unable to clear an environment's description. The new PATCH endpoint clears the description when an empty string is sent.

Adds Client.UpdateEnvironment + UpdateEnvironmentRequest in pkg/client, keeps CreateEnvironment (PUT) for the create path, and only sends included_environments for logical environments and never sends policies (managed by kosli_policy_attachment).