### PR TITLE
chore: change Slack channel ID to use vars

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
       - uses: kosli-dev/reusable-actions/slack-release-notify@main
         with:
           slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
-          slack-channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
+          slack-channel-id: ${{ vars.SLACK_CHANNEL_ID }}
           stage: start
 
   release:
@@ -138,6 +138,6 @@ jobs:
       - uses: kosli-dev/reusable-actions/slack-release-notify@main
         with:
           slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
-          slack-channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
+          slack-channel-id: ${{ vars.SLACK_CHANNEL_ID }}
           stage: finish
           status: ${{ steps.status.outputs.value }}


### PR DESCRIPTION
Updated Slack channel ID reference from secrets to vars.