### PR TITLE
fix: retry post-create read to avoid race condition

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,9 @@ on:
       - 'LICENSE'
       - '*.md'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+
 env:
   KOSLI_API_TOKEN: ${{ secrets.KOSLI_API_TOKEN }}
   KOSLI_ORG: ${{ vars.KOSLI_ORG }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+
 env:
   BUILD_NUMBER: ${{ github.run_number }}
   BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/pr-quality.yaml
+++ b/.github/workflows/pr-quality.yaml
@@ -8,6 +8,9 @@ on:
       - reopened
       - synchronize
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+
 jobs:
   validate-title:
     name: Validate PR Title

--- a/internal/provider/resource_custom_attestation_type.go
+++ b/internal/provider/resource_custom_attestation_type.go
@@ -147,7 +147,7 @@ func (r *customAttestationTypeResource) Create(ctx context.Context, req resource
 	)
 	if err != nil {
 		resp.Diagnostics.AddError(
-			afterCreateSummary("custom attestation type", err),
+			afterCreateSummary("Custom Attestation Type", err),
 			renameRaceDetail("custom attestation type", createReq.Name, err),
 		)
 		return

--- a/internal/provider/resource_custom_attestation_type.go
+++ b/internal/provider/resource_custom_attestation_type.go
@@ -133,8 +133,14 @@ func (r *customAttestationTypeResource) Create(ctx context.Context, req resource
 	}
 
 	// Per ADR 002: POST returns "OK", so we must GET to populate state.
+	// We pass nil for the rePut callback because CreateCustomAttestationType
+	// is a POST that allocates a new version on every call — re-issuing it
+	// during a rename-race retry (issue #121) would silently bump the
+	// version counter on the underlying type. The retry still surfaces the
+	// rename-race hint so users know to use `terraform state mv`; full
+	// recovery requires `state mv` or API support for upsert-on-archive.
 	attestationType, err := retryReadAfterCreate(ctx,
-		func(ctx context.Context) error { return r.client.CreateCustomAttestationType(ctx, createReq) },
+		nil,
 		func(ctx context.Context) (*client.CustomAttestationType, error) {
 			return r.client.GetCustomAttestationType(ctx, createReq.Name, nil)
 		},
@@ -142,8 +148,7 @@ func (r *customAttestationTypeResource) Create(ctx context.Context, req resource
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Reading Custom Attestation Type After Creation",
-			fmt.Sprintf("Could not read custom attestation type %q after creation: %s%s",
-				data.Name.ValueString(), err.Error(), renameRaceHint),
+			renameRaceDetail("custom attestation type", createReq.Name, err),
 		)
 		return
 	}

--- a/internal/provider/resource_custom_attestation_type.go
+++ b/internal/provider/resource_custom_attestation_type.go
@@ -132,12 +132,18 @@ func (r *customAttestationTypeResource) Create(ctx context.Context, req resource
 		return
 	}
 
-	// Per ADR 002: POST returns "OK", so we must GET to populate state
-	attestationType, err := r.client.GetCustomAttestationType(ctx, data.Name.ValueString(), nil)
+	// Per ADR 002: POST returns "OK", so we must GET to populate state.
+	attestationType, err := retryReadAfterCreate(ctx,
+		func(ctx context.Context) error { return r.client.CreateCustomAttestationType(ctx, createReq) },
+		func(ctx context.Context) (*client.CustomAttestationType, error) {
+			return r.client.GetCustomAttestationType(ctx, createReq.Name, nil)
+		},
+	)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Reading Custom Attestation Type After Creation",
-			fmt.Sprintf("Could not read custom attestation type %q after creation: %s", data.Name.ValueString(), err.Error()),
+			fmt.Sprintf("Could not read custom attestation type %q after creation: %s%s",
+				data.Name.ValueString(), err.Error(), renameRaceHint),
 		)
 		return
 	}

--- a/internal/provider/resource_custom_attestation_type.go
+++ b/internal/provider/resource_custom_attestation_type.go
@@ -147,7 +147,7 @@ func (r *customAttestationTypeResource) Create(ctx context.Context, req resource
 	)
 	if err != nil {
 		resp.Diagnostics.AddError(
-			"Error Reading Custom Attestation Type After Creation",
+			afterCreateSummary("custom attestation type", err),
 			renameRaceDetail("custom attestation type", createReq.Name, err),
 		)
 		return

--- a/internal/provider/resource_environment.go
+++ b/internal/provider/resource_environment.go
@@ -153,7 +153,7 @@ func (r *environmentResource) Create(ctx context.Context, req resource.CreateReq
 	)
 	if err != nil {
 		resp.Diagnostics.AddError(
-			afterCreateSummary("environment", err),
+			afterCreateSummary("Environment", err),
 			renameRaceDetail("environment", createReq.Name, err),
 		)
 		return

--- a/internal/provider/resource_environment.go
+++ b/internal/provider/resource_environment.go
@@ -153,7 +153,7 @@ func (r *environmentResource) Create(ctx context.Context, req resource.CreateReq
 	)
 	if err != nil {
 		resp.Diagnostics.AddError(
-			"Error Reading Environment After Creation",
+			afterCreateSummary("environment", err),
 			renameRaceDetail("environment", createReq.Name, err),
 		)
 		return

--- a/internal/provider/resource_environment.go
+++ b/internal/provider/resource_environment.go
@@ -137,8 +137,16 @@ func (r *environmentResource) Create(ctx context.Context, req resource.CreateReq
 	}
 
 	// Per ADR 002: PUT returns "OK", so we must GET to populate state.
+	// On 404, re-assert both the create PUT and the tags PATCH so a parallel
+	// destroy of a sibling resource sharing this name (label rename, see
+	// issue #121) can be recovered from in-place.
 	env, err := retryReadAfterCreate(ctx,
-		func(ctx context.Context) error { return r.client.CreateEnvironment(ctx, createReq) },
+		func(ctx context.Context) error {
+			if err := r.client.CreateEnvironment(ctx, createReq); err != nil {
+				return err
+			}
+			return applyTagsAsError(ctx, r.client, createReq.Name, "environment", types.MapNull(types.StringType), data.Tags)
+		},
 		func(ctx context.Context) (*client.Environment, error) {
 			return r.client.GetEnvironment(ctx, createReq.Name)
 		},
@@ -146,8 +154,7 @@ func (r *environmentResource) Create(ctx context.Context, req resource.CreateReq
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Reading Environment After Creation",
-			fmt.Sprintf("Could not read environment %q after creation: %s%s",
-				data.Name.ValueString(), err.Error(), renameRaceHint),
+			renameRaceDetail("environment", createReq.Name, err),
 		)
 		return
 	}

--- a/internal/provider/resource_environment.go
+++ b/internal/provider/resource_environment.go
@@ -136,12 +136,18 @@ func (r *environmentResource) Create(ctx context.Context, req resource.CreateReq
 		return
 	}
 
-	// Per ADR 002: PUT returns "OK", so we must GET to populate state
-	env, err := r.client.GetEnvironment(ctx, data.Name.ValueString())
+	// Per ADR 002: PUT returns "OK", so we must GET to populate state.
+	env, err := retryReadAfterCreate(ctx,
+		func(ctx context.Context) error { return r.client.CreateEnvironment(ctx, createReq) },
+		func(ctx context.Context) (*client.Environment, error) {
+			return r.client.GetEnvironment(ctx, createReq.Name)
+		},
+	)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Reading Environment After Creation",
-			fmt.Sprintf("Could not read environment %q after creation: %s", data.Name.ValueString(), err.Error()),
+			fmt.Sprintf("Could not read environment %q after creation: %s%s",
+				data.Name.ValueString(), err.Error(), renameRaceHint),
 		)
 		return
 	}

--- a/internal/provider/resource_flow.go
+++ b/internal/provider/resource_flow.go
@@ -146,7 +146,7 @@ func (r *flowResource) Create(ctx context.Context, req resource.CreateRequest, r
 	)
 	if err != nil {
 		resp.Diagnostics.AddError(
-			"Error Reading Flow After Creation",
+			afterCreateSummary("flow", err),
 			renameRaceDetail("flow", createReq.Name, err),
 		)
 		return

--- a/internal/provider/resource_flow.go
+++ b/internal/provider/resource_flow.go
@@ -146,7 +146,7 @@ func (r *flowResource) Create(ctx context.Context, req resource.CreateRequest, r
 	)
 	if err != nil {
 		resp.Diagnostics.AddError(
-			afterCreateSummary("flow", err),
+			afterCreateSummary("Flow", err),
 			renameRaceDetail("flow", createReq.Name, err),
 		)
 		return

--- a/internal/provider/resource_flow.go
+++ b/internal/provider/resource_flow.go
@@ -129,12 +129,18 @@ func (r *flowResource) Create(ctx context.Context, req resource.CreateRequest, r
 		return
 	}
 
-	// Per ADR 002: PUT returns "OK", so we must GET to populate state
-	flow, err := r.client.GetFlow(ctx, data.Name.ValueString())
+	// Per ADR 002: PUT returns "OK", so we must GET to populate state.
+	flow, err := retryReadAfterCreate(ctx,
+		func(ctx context.Context) error { return r.client.CreateFlow(ctx, createReq) },
+		func(ctx context.Context) (*client.Flow, error) {
+			return r.client.GetFlow(ctx, createReq.Name)
+		},
+	)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Reading Flow After Creation",
-			fmt.Sprintf("Could not read flow %q after creation: %s", data.Name.ValueString(), err.Error()),
+			fmt.Sprintf("Could not read flow %q after creation: %s%s",
+				data.Name.ValueString(), err.Error(), renameRaceHint),
 		)
 		return
 	}

--- a/internal/provider/resource_flow.go
+++ b/internal/provider/resource_flow.go
@@ -130,8 +130,16 @@ func (r *flowResource) Create(ctx context.Context, req resource.CreateRequest, r
 	}
 
 	// Per ADR 002: PUT returns "OK", so we must GET to populate state.
+	// On 404, re-assert both the create PUT and the tags PATCH so a parallel
+	// destroy of a sibling resource sharing this name (label rename, see
+	// issue #121) can be recovered from in-place.
 	flow, err := retryReadAfterCreate(ctx,
-		func(ctx context.Context) error { return r.client.CreateFlow(ctx, createReq) },
+		func(ctx context.Context) error {
+			if err := r.client.CreateFlow(ctx, createReq); err != nil {
+				return err
+			}
+			return applyTagsAsError(ctx, r.client, createReq.Name, "flow", types.MapNull(types.StringType), data.Tags)
+		},
 		func(ctx context.Context) (*client.Flow, error) {
 			return r.client.GetFlow(ctx, createReq.Name)
 		},
@@ -139,8 +147,7 @@ func (r *flowResource) Create(ctx context.Context, req resource.CreateRequest, r
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Reading Flow After Creation",
-			fmt.Sprintf("Could not read flow %q after creation: %s%s",
-				data.Name.ValueString(), err.Error(), renameRaceHint),
+			renameRaceDetail("flow", createReq.Name, err),
 		)
 		return
 	}

--- a/internal/provider/resource_logical_environment.go
+++ b/internal/provider/resource_logical_environment.go
@@ -154,12 +154,18 @@ func (r *logicalEnvironmentResource) Create(ctx context.Context, req resource.Cr
 		return
 	}
 
-	// Per ADR 002: PUT returns "OK", so we must GET to populate state
-	env, err := r.client.GetEnvironment(ctx, data.Name.ValueString())
+	// Per ADR 002: PUT returns "OK", so we must GET to populate state.
+	env, err := retryReadAfterCreate(ctx,
+		func(ctx context.Context) error { return r.client.CreateEnvironment(ctx, createReq) },
+		func(ctx context.Context) (*client.Environment, error) {
+			return r.client.GetEnvironment(ctx, createReq.Name)
+		},
+	)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Reading Logical Environment After Creation",
-			fmt.Sprintf("Could not read logical environment %q after creation: %s", data.Name.ValueString(), err.Error()),
+			fmt.Sprintf("Could not read logical environment %q after creation: %s%s",
+				data.Name.ValueString(), err.Error(), renameRaceHint),
 		)
 		return
 	}

--- a/internal/provider/resource_logical_environment.go
+++ b/internal/provider/resource_logical_environment.go
@@ -171,7 +171,7 @@ func (r *logicalEnvironmentResource) Create(ctx context.Context, req resource.Cr
 	)
 	if err != nil {
 		resp.Diagnostics.AddError(
-			"Error Reading Logical Environment After Creation",
+			afterCreateSummary("logical environment", err),
 			renameRaceDetail("logical environment", createReq.Name, err),
 		)
 		return

--- a/internal/provider/resource_logical_environment.go
+++ b/internal/provider/resource_logical_environment.go
@@ -171,7 +171,7 @@ func (r *logicalEnvironmentResource) Create(ctx context.Context, req resource.Cr
 	)
 	if err != nil {
 		resp.Diagnostics.AddError(
-			afterCreateSummary("logical environment", err),
+			afterCreateSummary("Logical Environment", err),
 			renameRaceDetail("logical environment", createReq.Name, err),
 		)
 		return

--- a/internal/provider/resource_logical_environment.go
+++ b/internal/provider/resource_logical_environment.go
@@ -155,8 +155,16 @@ func (r *logicalEnvironmentResource) Create(ctx context.Context, req resource.Cr
 	}
 
 	// Per ADR 002: PUT returns "OK", so we must GET to populate state.
+	// On 404, re-assert both the create PUT and the tags PATCH so a parallel
+	// destroy of a sibling resource sharing this name (label rename, see
+	// issue #121) can be recovered from in-place.
 	env, err := retryReadAfterCreate(ctx,
-		func(ctx context.Context) error { return r.client.CreateEnvironment(ctx, createReq) },
+		func(ctx context.Context) error {
+			if err := r.client.CreateEnvironment(ctx, createReq); err != nil {
+				return err
+			}
+			return applyTagsAsError(ctx, r.client, createReq.Name, "environment", types.MapNull(types.StringType), data.Tags)
+		},
 		func(ctx context.Context) (*client.Environment, error) {
 			return r.client.GetEnvironment(ctx, createReq.Name)
 		},
@@ -164,8 +172,7 @@ func (r *logicalEnvironmentResource) Create(ctx context.Context, req resource.Cr
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Reading Logical Environment After Creation",
-			fmt.Sprintf("Could not read logical environment %q after creation: %s%s",
-				data.Name.ValueString(), err.Error(), renameRaceHint),
+			renameRaceDetail("logical environment", createReq.Name, err),
 		)
 		return
 	}

--- a/internal/provider/retry_after_create.go
+++ b/internal/provider/retry_after_create.go
@@ -95,16 +95,42 @@ func renameRaceDetail(kind, name string, err error) string {
 	return detail
 }
 
+// afterCreateSummary returns the diagnostic summary that best describes a
+// post-create failure. Tag-PATCH failures returned from the rePut closure
+// (identified via ErrTagApplyFailed) are surfaced as a tag update error so
+// users aren't misled by a "Reading ... After Creation" header. All other
+// errors keep the read-after-creation summary.
+func afterCreateSummary(kind string, err error) string {
+	if errors.Is(err, ErrTagApplyFailed) {
+		return fmt.Sprintf("Error Updating %s Tags", titleCase(kind))
+	}
+	return fmt.Sprintf("Error Reading %s After Creation", titleCase(kind))
+}
+
+// ErrTagApplyFailed wraps errors returned by applyTagsAsError so call sites
+// using the helper inside a retry closure can distinguish tag-PATCH failures
+// from create/read failures and surface a more accurate diagnostic summary
+// (e.g. "Error Updating Environment Tags" instead of "Error Reading
+// Environment After Creation").
+var ErrTagApplyFailed = errors.New("applying tags failed")
+
 // applyTagsAsError invokes applyTags and collapses any error-severity
-// diagnostics into a single error. Used inside retry closures where the
-// surrounding code expects an `error` return rather than a *diag.Diagnostics.
+// diagnostics into a single error using errors.Join so all reported errors
+// are preserved. The combined error is wrapped with ErrTagApplyFailed so
+// callers can identify it via errors.Is. Used inside retry closures where
+// the surrounding code expects an `error` return rather than a
+// *diag.Diagnostics.
 func applyTagsAsError(ctx context.Context, c *client.Client, name, resourceType string, oldTags, newTags types.Map) error {
 	var d diag.Diagnostics
 	applyTags(ctx, c, name, resourceType, oldTags, newTags, &d)
+	var errs []error
 	for _, entry := range d {
 		if entry.Severity() == diag.SeverityError {
-			return fmt.Errorf("%s: %s", entry.Summary(), entry.Detail())
+			errs = append(errs, fmt.Errorf("%s: %s", entry.Summary(), entry.Detail()))
 		}
 	}
-	return nil
+	if len(errs) == 0 {
+		return nil
+	}
+	return fmt.Errorf("%w: %w", ErrTagApplyFailed, errors.Join(errs...))
 }

--- a/internal/provider/retry_after_create.go
+++ b/internal/provider/retry_after_create.go
@@ -99,12 +99,14 @@ func renameRaceDetail(kind, name string, err error) string {
 // post-create failure. Tag-PATCH failures returned from the rePut closure
 // (identified via ErrTagApplyFailed) are surfaced as a tag update error so
 // users aren't misled by a "Reading ... After Creation" header. All other
-// errors keep the read-after-creation summary.
-func afterCreateSummary(kind string, err error) string {
+// errors keep the read-after-creation summary. displayKind must already be
+// in the casing the user should see (e.g. "Logical Environment") so this
+// helper agrees with sibling diagnostics emitted on non-retry code paths.
+func afterCreateSummary(displayKind string, err error) string {
 	if errors.Is(err, ErrTagApplyFailed) {
-		return fmt.Sprintf("Error Updating %s Tags", titleCase(kind))
+		return fmt.Sprintf("Error Updating %s Tags", displayKind)
 	}
-	return fmt.Sprintf("Error Reading %s After Creation", titleCase(kind))
+	return fmt.Sprintf("Error Reading %s After Creation", displayKind)
 }
 
 // ErrTagApplyFailed wraps errors returned by applyTagsAsError so call sites

--- a/internal/provider/retry_after_create.go
+++ b/internal/provider/retry_after_create.go
@@ -1,0 +1,57 @@
+package provider
+
+import (
+	"context"
+	"time"
+
+	"github.com/kosli-dev/terraform-provider-kosli/pkg/client"
+)
+
+// retryReadAfterCreate fetches a resource immediately after Create. If the
+// initial GET returns 404, a sibling resource with the same name is being
+// destroyed in parallel (e.g. a Terraform label rename plans as parallel
+// destroy + create against the same Kosli resource). The destroy may archive
+// the resource between our PUT and our GET.
+//
+// On 404, the helper waits, re-issues the create PUT to re-assert desired
+// state, and re-GETs. Bounded backoff; non-404 errors are returned
+// immediately. See issue #121.
+func retryReadAfterCreate[T any](
+	ctx context.Context,
+	rePut func(context.Context) error,
+	get func(context.Context) (*T, error),
+) (*T, error) {
+	backoffs := []time.Duration{500 * time.Millisecond, 1 * time.Second, 2 * time.Second, 4 * time.Second}
+
+	v, err := get(ctx)
+	if err == nil {
+		return v, nil
+	}
+
+	for _, wait := range backoffs {
+		if !client.IsNotFound(err) {
+			return nil, err
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(wait):
+		}
+		if rePutErr := rePut(ctx); rePutErr != nil {
+			return nil, rePutErr
+		}
+		v, err = get(ctx)
+		if err == nil {
+			return v, nil
+		}
+	}
+
+	return nil, err
+}
+
+// renameRaceHint is appended to "Error Reading ... After Creation" diagnostics
+// to point users at the correct workaround for an intentional label rename.
+const renameRaceHint = "\n\nThis can happen when a Terraform resource label is renamed while keeping the same `name`: " +
+	"Terraform plans the rename as a parallel destroy + create that target the same Kosli resource, " +
+	"and the destroy can archive the resource before this read. To rename the resource label without " +
+	"recreating, use `terraform state mv` instead."

--- a/internal/provider/retry_after_create.go
+++ b/internal/provider/retry_after_create.go
@@ -2,10 +2,31 @@ package provider
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/kosli-dev/terraform-provider-kosli/pkg/client"
 )
+
+// ErrRenameRace is returned by retryReadAfterCreate when every retry attempt
+// observes a 404. Callers use errors.Is to decide whether to append the
+// rename-race hint to user diagnostics; transient errors (5xx, context
+// cancellation, re-PUT failures) are returned as-is and don't trigger the
+// hint. See issue #121.
+var ErrRenameRace = errors.New("post-create read kept returning 404 (likely Terraform label rename racing destroy on the same resource)")
+
+// retryAfterCreateBackoffs controls the sleep schedule between retry
+// attempts in retryReadAfterCreate. Exposed as a package-level var so tests
+// can override it to avoid real sleeps.
+var retryAfterCreateBackoffs = []time.Duration{
+	500 * time.Millisecond,
+	1 * time.Second,
+	2 * time.Second,
+	4 * time.Second,
+}
 
 // retryReadAfterCreate fetches a resource immediately after Create. If the
 // initial GET returns 404, a sibling resource with the same name is being
@@ -13,22 +34,24 @@ import (
 // destroy + create against the same Kosli resource). The destroy may archive
 // the resource between our PUT and our GET.
 //
-// On 404, the helper waits, re-issues the create PUT to re-assert desired
-// state, and re-GETs. Bounded backoff; non-404 errors are returned
-// immediately. See issue #121.
+// On 404, the helper waits, optionally re-asserts desired state via rePut,
+// and re-GETs. Pass rePut=nil to skip re-asserting (useful when the
+// underlying create endpoint is non-idempotent and re-issuing it would have
+// side effects, such as creating a new version). Bounded backoff; non-404
+// errors are returned immediately as-is. If every attempt returns 404, the
+// final error is wrapped with ErrRenameRace so callers can identify the
+// rename-race scenario specifically.
 func retryReadAfterCreate[T any](
 	ctx context.Context,
 	rePut func(context.Context) error,
 	get func(context.Context) (*T, error),
 ) (*T, error) {
-	backoffs := []time.Duration{500 * time.Millisecond, 1 * time.Second, 2 * time.Second, 4 * time.Second}
-
 	v, err := get(ctx)
 	if err == nil {
 		return v, nil
 	}
 
-	for _, wait := range backoffs {
+	for _, wait := range retryAfterCreateBackoffs {
 		if !client.IsNotFound(err) {
 			return nil, err
 		}
@@ -37,8 +60,10 @@ func retryReadAfterCreate[T any](
 			return nil, ctx.Err()
 		case <-time.After(wait):
 		}
-		if rePutErr := rePut(ctx); rePutErr != nil {
-			return nil, rePutErr
+		if rePut != nil {
+			if rePutErr := rePut(ctx); rePutErr != nil {
+				return nil, rePutErr
+			}
 		}
 		v, err = get(ctx)
 		if err == nil {
@@ -46,12 +71,40 @@ func retryReadAfterCreate[T any](
 		}
 	}
 
+	if client.IsNotFound(err) {
+		return nil, fmt.Errorf("%w: %w", ErrRenameRace, err)
+	}
 	return nil, err
 }
 
 // renameRaceHint is appended to "Error Reading ... After Creation" diagnostics
-// to point users at the correct workaround for an intentional label rename.
+// only when the underlying error is ErrRenameRace, to point users at the
+// correct workaround for an intentional label rename.
 const renameRaceHint = "\n\nThis can happen when a Terraform resource label is renamed while keeping the same `name`: " +
 	"Terraform plans the rename as a parallel destroy + create that target the same Kosli resource, " +
-	"and the destroy can archive the resource before this read. To rename the resource label without " +
-	"recreating, use `terraform state mv` instead."
+	"and the destroy can remove or archive the resource before this read completes. To rename the " +
+	"resource label without recreating, use `terraform state mv` instead."
+
+// renameRaceDetail formats a "Could not read X after creation" diagnostic
+// detail, appending renameRaceHint only when err is an ErrRenameRace.
+func renameRaceDetail(kind, name string, err error) string {
+	detail := fmt.Sprintf("Could not read %s %q after creation: %s", kind, name, err.Error())
+	if errors.Is(err, ErrRenameRace) {
+		detail += renameRaceHint
+	}
+	return detail
+}
+
+// applyTagsAsError invokes applyTags and collapses any error-severity
+// diagnostics into a single error. Used inside retry closures where the
+// surrounding code expects an `error` return rather than a *diag.Diagnostics.
+func applyTagsAsError(ctx context.Context, c *client.Client, name, resourceType string, oldTags, newTags types.Map) error {
+	var d diag.Diagnostics
+	applyTags(ctx, c, name, resourceType, oldTags, newTags, &d)
+	for _, entry := range d {
+		if entry.Severity() == diag.SeverityError {
+			return fmt.Errorf("%s: %s", entry.Summary(), entry.Detail())
+		}
+	}
+	return nil
+}

--- a/internal/provider/retry_after_create_test.go
+++ b/internal/provider/retry_after_create_test.go
@@ -199,15 +199,21 @@ func TestRenameRaceDetail_AppendsHintOnlyForRenameRace(t *testing.T) {
 
 func TestAfterCreateSummary_TagFailureRoutedToTagSummary(t *testing.T) {
 	tagErr := fmt.Errorf("%w: %w", ErrTagApplyFailed, errors.New("PATCH failed"))
-	if got := afterCreateSummary("environment", tagErr); got != "Error Updating Environment Tags" {
+	if got := afterCreateSummary("Environment", tagErr); got != "Error Updating Environment Tags" {
 		t.Errorf("expected tag-summary header, got %q", got)
 	}
-	if got := afterCreateSummary("logical environment", tagErr); got != "Error Updating Logical environment Tags" {
-		t.Errorf("expected logical environment tag header, got %q", got)
+	// Multi-word display labels must be honoured verbatim so retry-path
+	// summaries agree with sibling non-retry summaries (e.g. "Logical
+	// Environment", "Custom Attestation Type").
+	if got := afterCreateSummary("Logical Environment", tagErr); got != "Error Updating Logical Environment Tags" {
+		t.Errorf("expected fully-cased multi-word tag header, got %q", got)
 	}
 	other := errors.New("nope")
-	if got := afterCreateSummary("flow", other); got != "Error Reading Flow After Creation" {
+	if got := afterCreateSummary("Flow", other); got != "Error Reading Flow After Creation" {
 		t.Errorf("expected read-after-creation header for non-tag error, got %q", got)
+	}
+	if got := afterCreateSummary("Custom Attestation Type", other); got != "Error Reading Custom Attestation Type After Creation" {
+		t.Errorf("expected fully-cased multi-word read header, got %q", got)
 	}
 }
 

--- a/internal/provider/retry_after_create_test.go
+++ b/internal/provider/retry_after_create_test.go
@@ -1,0 +1,108 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/kosli-dev/terraform-provider-kosli/pkg/client"
+)
+
+func TestRetryReadAfterCreate_SuccessNoRetry(t *testing.T) {
+	var puts, gets int
+	v, err := retryReadAfterCreate(context.Background(),
+		func(context.Context) error { puts++; return nil },
+		func(context.Context) (*string, error) {
+			gets++
+			s := "ok"
+			return &s, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v == nil || *v != "ok" {
+		t.Fatalf("unexpected value: %v", v)
+	}
+	if puts != 0 {
+		t.Errorf("expected 0 re-PUTs, got %d", puts)
+	}
+	if gets != 1 {
+		t.Errorf("expected 1 GET, got %d", gets)
+	}
+}
+
+func TestRetryReadAfterCreate_RetriesOn404(t *testing.T) {
+	notFound := &client.APIError{StatusCode: http.StatusNotFound, Message: "archived"}
+	var puts, gets int
+	v, err := retryReadAfterCreate(context.Background(),
+		func(context.Context) error { puts++; return nil },
+		func(context.Context) (*string, error) {
+			gets++
+			if gets == 1 {
+				return nil, notFound
+			}
+			s := "ok"
+			return &s, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("expected success after retry, got %v", err)
+	}
+	if v == nil || *v != "ok" {
+		t.Fatalf("unexpected value: %v", v)
+	}
+	if puts != 1 {
+		t.Errorf("expected 1 re-PUT after initial 404, got %d", puts)
+	}
+	if gets != 2 {
+		t.Errorf("expected 2 GETs, got %d", gets)
+	}
+}
+
+func TestRetryReadAfterCreate_NonNotFoundReturnsImmediately(t *testing.T) {
+	boom := errors.New("boom")
+	var puts, gets int
+	_, err := retryReadAfterCreate(context.Background(),
+		func(context.Context) error { puts++; return nil },
+		func(context.Context) (*string, error) {
+			gets++
+			return nil, boom
+		},
+	)
+	if !errors.Is(err, boom) {
+		t.Fatalf("expected boom, got %v", err)
+	}
+	if puts != 0 {
+		t.Errorf("expected 0 re-PUTs on non-404, got %d", puts)
+	}
+	if gets != 1 {
+		t.Errorf("expected 1 GET on non-404, got %d", gets)
+	}
+}
+
+func TestRetryReadAfterCreate_PutErrorPropagates(t *testing.T) {
+	notFound := &client.APIError{StatusCode: http.StatusNotFound}
+	putErr := errors.New("put failed")
+	_, err := retryReadAfterCreate(context.Background(),
+		func(context.Context) error { return putErr },
+		func(context.Context) (*string, error) { return nil, notFound },
+	)
+	if !errors.Is(err, putErr) {
+		t.Fatalf("expected put error to propagate, got %v", err)
+	}
+}
+
+func TestRetryReadAfterCreate_ContextCancelled(t *testing.T) {
+	notFound := &client.APIError{StatusCode: http.StatusNotFound}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := retryReadAfterCreate(ctx,
+		func(context.Context) error { return nil },
+		func(context.Context) (*string, error) { return nil, notFound },
+	)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+}

--- a/internal/provider/retry_after_create_test.go
+++ b/internal/provider/retry_after_create_test.go
@@ -5,11 +5,23 @@ import (
 	"errors"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/kosli-dev/terraform-provider-kosli/pkg/client"
 )
 
+// withFastBackoffs replaces the package-level backoff schedule with zero-duration
+// waits for the duration of a test, restoring it on cleanup. Keeps the actual
+// retry count intact so tests can assert how many attempts were made.
+func withFastBackoffs(t *testing.T) {
+	t.Helper()
+	prev := retryAfterCreateBackoffs
+	retryAfterCreateBackoffs = make([]time.Duration, len(prev))
+	t.Cleanup(func() { retryAfterCreateBackoffs = prev })
+}
+
 func TestRetryReadAfterCreate_SuccessNoRetry(t *testing.T) {
+	withFastBackoffs(t)
 	var puts, gets int
 	v, err := retryReadAfterCreate(context.Background(),
 		func(context.Context) error { puts++; return nil },
@@ -34,6 +46,7 @@ func TestRetryReadAfterCreate_SuccessNoRetry(t *testing.T) {
 }
 
 func TestRetryReadAfterCreate_RetriesOn404(t *testing.T) {
+	withFastBackoffs(t)
 	notFound := &client.APIError{StatusCode: http.StatusNotFound, Message: "archived"}
 	var puts, gets int
 	v, err := retryReadAfterCreate(context.Background(),
@@ -62,6 +75,7 @@ func TestRetryReadAfterCreate_RetriesOn404(t *testing.T) {
 }
 
 func TestRetryReadAfterCreate_NonNotFoundReturnsImmediately(t *testing.T) {
+	withFastBackoffs(t)
 	boom := errors.New("boom")
 	var puts, gets int
 	_, err := retryReadAfterCreate(context.Background(),
@@ -74,6 +88,9 @@ func TestRetryReadAfterCreate_NonNotFoundReturnsImmediately(t *testing.T) {
 	if !errors.Is(err, boom) {
 		t.Fatalf("expected boom, got %v", err)
 	}
+	if errors.Is(err, ErrRenameRace) {
+		t.Fatalf("non-404 errors must not be wrapped with ErrRenameRace, got %v", err)
+	}
 	if puts != 0 {
 		t.Errorf("expected 0 re-PUTs on non-404, got %d", puts)
 	}
@@ -83,6 +100,7 @@ func TestRetryReadAfterCreate_NonNotFoundReturnsImmediately(t *testing.T) {
 }
 
 func TestRetryReadAfterCreate_PutErrorPropagates(t *testing.T) {
+	withFastBackoffs(t)
 	notFound := &client.APIError{StatusCode: http.StatusNotFound}
 	putErr := errors.New("put failed")
 	_, err := retryReadAfterCreate(context.Background(),
@@ -92,9 +110,13 @@ func TestRetryReadAfterCreate_PutErrorPropagates(t *testing.T) {
 	if !errors.Is(err, putErr) {
 		t.Fatalf("expected put error to propagate, got %v", err)
 	}
+	if errors.Is(err, ErrRenameRace) {
+		t.Fatalf("re-PUT errors must not be wrapped with ErrRenameRace, got %v", err)
+	}
 }
 
 func TestRetryReadAfterCreate_ContextCancelled(t *testing.T) {
+	withFastBackoffs(t)
 	notFound := &client.APIError{StatusCode: http.StatusNotFound}
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -105,4 +127,79 @@ func TestRetryReadAfterCreate_ContextCancelled(t *testing.T) {
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("expected context.Canceled, got %v", err)
 	}
+	if errors.Is(err, ErrRenameRace) {
+		t.Fatalf("context.Canceled must not be wrapped with ErrRenameRace, got %v", err)
+	}
+}
+
+// TestRetryReadAfterCreate_ExhaustedRetriesWrapsRenameRace asserts that when
+// every GET attempt returns 404 the helper wraps the final error with
+// ErrRenameRace. It also pins the number of attempts to len(backoffs)+1
+// (initial + one per backoff entry) so accidental changes to the schedule
+// surface as test failures.
+func TestRetryReadAfterCreate_ExhaustedRetriesWrapsRenameRace(t *testing.T) {
+	withFastBackoffs(t)
+	notFound := &client.APIError{StatusCode: http.StatusNotFound, Message: "archived"}
+	var puts, gets int
+	_, err := retryReadAfterCreate(context.Background(),
+		func(context.Context) error { puts++; return nil },
+		func(context.Context) (*string, error) { gets++; return nil, notFound },
+	)
+	if err == nil {
+		t.Fatal("expected error after exhausting retries")
+	}
+	if !errors.Is(err, ErrRenameRace) {
+		t.Errorf("expected ErrRenameRace wrap, got %v", err)
+	}
+	if !client.IsNotFound(err) {
+		t.Errorf("expected wrapped error to still satisfy IsNotFound, got %v", err)
+	}
+	wantGets := len(retryAfterCreateBackoffs) + 1
+	if gets != wantGets {
+		t.Errorf("expected %d GETs (initial + 1 per backoff), got %d", wantGets, gets)
+	}
+	if puts != len(retryAfterCreateBackoffs) {
+		t.Errorf("expected %d re-PUTs (one per backoff), got %d", len(retryAfterCreateBackoffs), puts)
+	}
+}
+
+// TestRetryReadAfterCreate_NilRePutSkipsReassert covers the path used by
+// kosli_custom_attestation_type, where the create endpoint is a POST that
+// allocates a new version on every call and so must not be re-issued.
+func TestRetryReadAfterCreate_NilRePutSkipsReassert(t *testing.T) {
+	withFastBackoffs(t)
+	notFound := &client.APIError{StatusCode: http.StatusNotFound}
+	var gets int
+	_, err := retryReadAfterCreate[string](context.Background(),
+		nil,
+		func(context.Context) (*string, error) { gets++; return nil, notFound },
+	)
+	if !errors.Is(err, ErrRenameRace) {
+		t.Fatalf("expected ErrRenameRace, got %v", err)
+	}
+	if gets != len(retryAfterCreateBackoffs)+1 {
+		t.Errorf("expected GETs to be retried even without rePut, got %d", gets)
+	}
+}
+
+func TestRenameRaceDetail_AppendsHintOnlyForRenameRace(t *testing.T) {
+	notFound := &client.APIError{StatusCode: http.StatusNotFound, Message: "archived"}
+	raceErr := errors.Join(ErrRenameRace, notFound)
+	if got := renameRaceDetail("environment", "test", raceErr); !contains(got, "terraform state mv") {
+		t.Errorf("expected rename hint for ErrRenameRace, got: %s", got)
+	}
+
+	transient := errors.New("upstream 503")
+	if got := renameRaceDetail("environment", "test", transient); contains(got, "terraform state mv") {
+		t.Errorf("did not expect rename hint for non-rename error, got: %s", got)
+	}
+}
+
+func contains(haystack, needle string) bool {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/provider/retry_after_create_test.go
+++ b/internal/provider/retry_after_create_test.go
@@ -3,7 +3,9 @@ package provider
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -185,21 +187,41 @@ func TestRetryReadAfterCreate_NilRePutSkipsReassert(t *testing.T) {
 func TestRenameRaceDetail_AppendsHintOnlyForRenameRace(t *testing.T) {
 	notFound := &client.APIError{StatusCode: http.StatusNotFound, Message: "archived"}
 	raceErr := errors.Join(ErrRenameRace, notFound)
-	if got := renameRaceDetail("environment", "test", raceErr); !contains(got, "terraform state mv") {
+	if got := renameRaceDetail("environment", "test", raceErr); !strings.Contains(got, "terraform state mv") {
 		t.Errorf("expected rename hint for ErrRenameRace, got: %s", got)
 	}
 
 	transient := errors.New("upstream 503")
-	if got := renameRaceDetail("environment", "test", transient); contains(got, "terraform state mv") {
+	if got := renameRaceDetail("environment", "test", transient); strings.Contains(got, "terraform state mv") {
 		t.Errorf("did not expect rename hint for non-rename error, got: %s", got)
 	}
 }
 
-func contains(haystack, needle string) bool {
-	for i := 0; i+len(needle) <= len(haystack); i++ {
-		if haystack[i:i+len(needle)] == needle {
-			return true
-		}
+func TestAfterCreateSummary_TagFailureRoutedToTagSummary(t *testing.T) {
+	tagErr := fmt.Errorf("%w: %w", ErrTagApplyFailed, errors.New("PATCH failed"))
+	if got := afterCreateSummary("environment", tagErr); got != "Error Updating Environment Tags" {
+		t.Errorf("expected tag-summary header, got %q", got)
 	}
-	return false
+	if got := afterCreateSummary("logical environment", tagErr); got != "Error Updating Logical environment Tags" {
+		t.Errorf("expected logical environment tag header, got %q", got)
+	}
+	other := errors.New("nope")
+	if got := afterCreateSummary("flow", other); got != "Error Reading Flow After Creation" {
+		t.Errorf("expected read-after-creation header for non-tag error, got %q", got)
+	}
+}
+
+func TestApplyTagsAsError_PreservesAllDiagnostics(t *testing.T) {
+	// We can exercise the join behaviour without spinning up a real client by
+	// constructing the same kind of joined error the helper builds and
+	// asserting both inner errors are reachable via errors.Is.
+	first := errors.New("set-tag failed: a")
+	second := errors.New("remove-tag failed: b")
+	joined := fmt.Errorf("%w: %w", ErrTagApplyFailed, errors.Join(first, second))
+	if !errors.Is(joined, ErrTagApplyFailed) {
+		t.Error("expected ErrTagApplyFailed to be reachable")
+	}
+	if !errors.Is(joined, first) || !errors.Is(joined, second) {
+		t.Error("expected both joined errors to be reachable")
+	}
 }


### PR DESCRIPTION
Fixes: #121 

When a Terraform resource label is renamed while keeping the same `name`,
Terraform plans a parallel destroy + create against the same Kosli
environment. The destroy's archive call can land between our create PUT
and the post-create GET, surfacing a 404 ("Environment ... has been
archived") even though the apply just succeeded (issue https://github.com/kosli-dev/terraform-provider-kosli/issues/121).

Make the post-create read tolerate that race: on 404, re-PUT to re-assert
the desired state and re-GET, with bounded backoff. If the retries are
exhausted, return a diagnostic that names the rename-race scenario and
points users at `terraform state mv` as the correct workaround for an
intentional label rename.

The retry only converges when the API treats PUT on an archived
environment as an upsert (or once destroy has fully completed); a
follow-up API change is required for full race-proof behaviour
regardless of ordering.