### PR TITLE
fix: deflake TestRetryReadAfterCreate_ContextCancelled

### DIFF
--- a/internal/provider/retry_after_create.go
+++ b/internal/provider/retry_after_create.go
@@ -52,6 +52,9 @@ func retryReadAfterCreate[T any](
 	}
 
 	for _, wait := range retryAfterCreateBackoffs {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
 		if !client.IsNotFound(err) {
 			return nil, err
 		}


### PR DESCRIPTION
## Summary
- `TestRetryReadAfterCreate_ContextCancelled` was flaky: `withFastBackoffs` rewrites the backoff schedule to zero durations, so the `select` in `retryReadAfterCreate` had both `ctx.Done()` and `time.After(0)` ready at the same time. Go picks randomly when multiple `select` cases are ready, so cancellation only won some runs.
- Check `ctx.Err()` at the top of each loop iteration so cancellation is honored deterministically, regardless of timer readiness.

## Context
Surfaced on the PR-quality workflow update in #200 — see the failing job: https://github.com/kosli-dev/terraform-provider-kosli/actions/runs/26746596976/job/78823549235?pr=200

## Test plan
- [x] `go test -run TestRetryReadAfterCreate -count=50 ./internal/provider/` passes 50/50 locally
- [ ] CI green