### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,10 +26,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           check-latest: true
           go-version-file: '.go-version'
@@ -60,7 +60,7 @@ jobs:
         run: make vet
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         with:
           version: latest
           args: --timeout=5m
@@ -79,10 +79,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           check-latest: true
           go-version-file: '.go-version'
@@ -91,7 +91,7 @@ jobs:
         run: make build
 
       - name: Upload provider binary for validation
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: terraform-provider-kosli
           path: terraform-provider-kosli
@@ -123,16 +123,16 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           check-latest: true
           go-version-file: '.go-version'
 
       - name: Download provider binary
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: terraform-provider-kosli
 
@@ -140,7 +140,7 @@ jobs:
         run: chmod +x terraform-provider-kosli
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v4
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
           terraform_version: "~1.10.0"
           terraform_wrapper: false

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -32,10 +32,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Kosli CLI
-        uses: kosli-dev/setup-cli-action@v5
+        uses: kosli-dev/setup-cli-action@db670fb701b8158a46477616686df59fea459b9a # v5.0.1
         with:
           version: ${{ env.KOSLI_VERSION }}
 
@@ -60,10 +60,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Kosli CLI
-        uses: kosli-dev/setup-cli-action@v5
+        uses: kosli-dev/setup-cli-action@db670fb701b8158a46477616686df59fea459b9a # v5.0.1
         with:
           version: ${{ env.KOSLI_VERSION }}
 
@@ -84,15 +84,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Kosli CLI
-        uses: kosli-dev/setup-cli-action@v5
+        uses: kosli-dev/setup-cli-action@db670fb701b8158a46477616686df59fea459b9a # v5.0.1
         with:
           version: ${{ env.KOSLI_VERSION }}
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           check-latest: true
           go-version-file: '.go-version'
@@ -109,7 +109,7 @@ jobs:
         run: make vet
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         with:
           version: latest
           args: --timeout=5m
@@ -160,15 +160,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Kosli CLI
-        uses: kosli-dev/setup-cli-action@v5
+        uses: kosli-dev/setup-cli-action@db670fb701b8158a46477616686df59fea459b9a # v5.0.1
         with:
           version: ${{ env.KOSLI_VERSION }}
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           check-latest: true
           go-version-file: '.go-version'
@@ -187,7 +187,7 @@ jobs:
             --commit-url ${COMMIT_URL}
 
       - name: Generate SBOM for the Go binary
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           artifact-name: sbom-spdx.json
           file: ./terraform-provider-kosli
@@ -205,7 +205,7 @@ jobs:
             --attachments sbom-spdx.json
 
       - name: Upload provider binary
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: terraform-provider-kosli
           path: terraform-provider-kosli
@@ -237,16 +237,16 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           check-latest: true
           go-version-file: '.go-version'
 
       - name: Download provider binary
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: terraform-provider-kosli
 
@@ -254,7 +254,7 @@ jobs:
         run: chmod +x terraform-provider-kosli
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v4
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
           terraform_version: "~1.10.0"
           terraform_wrapper: false

--- a/.github/workflows/pr-quality.yaml
+++ b/.github/workflows/pr-quality.yaml
@@ -60,7 +60,9 @@ jobs:
         with:
           fetch-depth: 1
 
-      - uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1.0.133
+      # TODO: re-pin to a commit SHA once WIF auth is confirmed working on the
+      # federation-auth PR (#200). Tracked for a follow-up PR.
+      - uses: anthropics/claude-code-action@v1
         with:
           anthropic_federation_rule_id: ${{ vars.ANTHROPIC_FEDERATION_RULE_ID }}
           anthropic_organization_id: ${{ vars.ANTHROPIC_ORGANIZATION_ID }}

--- a/.github/workflows/pr-quality.yaml
+++ b/.github/workflows/pr-quality.yaml
@@ -60,9 +60,7 @@ jobs:
         with:
           fetch-depth: 1
 
-      # TODO: re-pin to a commit SHA once WIF auth is confirmed working on the
-      # federation-auth PR (#200). Tracked for a follow-up PR.
-      - uses: anthropics/claude-code-action@v1
+      - uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1.0.133
         with:
           anthropic_federation_rule_id: ${{ vars.ANTHROPIC_FEDERATION_RULE_ID }}
           anthropic_organization_id: ${{ vars.ANTHROPIC_ORGANIZATION_ID }}

--- a/.github/workflows/pr-quality.yaml
+++ b/.github/workflows/pr-quality.yaml
@@ -19,7 +19,7 @@ jobs:
       pull-requests: read
     steps:
       - name: Check PR title follows Conventional Commit format
-        uses: amannn/action-semantic-pull-request@v6
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -56,11 +56,11 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 
-      - uses: anthropics/claude-code-action@v1
+      - uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1.0.133
         with:
           anthropic_federation_rule_id: ${{ vars.ANTHROPIC_FEDERATION_RULE_ID }}
           anthropic_organization_id: ${{ vars.ANTHROPIC_ORGANIZATION_ID }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ jobs:
   notify-start:
     runs-on: ubuntu-latest
     steps:
-      - uses: kosli-dev/reusable-actions/slack-release-notify@main
+      - uses: kosli-dev/reusable-actions/slack-release-notify@f739efd12323329b5656fbbda9d843a836ace5ff # main
         with:
           slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
           slack-channel-id: ${{ vars.SLACK_CHANNEL_ID }}
@@ -24,24 +24,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           check-latest: true
           go-version-file: '.go-version'
 
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v7
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
         id: import_gpg
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
           distribution: goreleaser
           version: '~> v2' # current latest
@@ -108,7 +108,7 @@ jobs:
           mv /tmp/cl.md CHANGELOG.md
 
       - name: Create changelog PR
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: changelog/${{ github.ref_name }}
@@ -136,7 +136,7 @@ jobs:
             echo "value=failure" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: kosli-dev/reusable-actions/slack-release-notify@main
+      - uses: kosli-dev/reusable-actions/slack-release-notify@f739efd12323329b5656fbbda9d843a836ace5ff # main
         with:
           slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
           slack-channel-id: ${{ vars.SLACK_CHANNEL_ID }}


### PR DESCRIPTION
## Summary
Pin every action reference across `ci.yaml`, `main.yaml`, `pr-quality.yaml`, and `release.yaml` to a full commit SHA, with the resolved version as a trailing `# v<version>` comment for readability.

Actions pinned (latest release as of 2026-06-01):
- `actions/checkout` → v6.0.2
- `actions/setup-go` → v6.4.0
- `actions/upload-artifact` → v7.0.1
- `actions/download-artifact` → v8.0.1
- `golangci/golangci-lint-action` → v9.2.1
- `hashicorp/setup-terraform` → v4.0.1
- `amannn/action-semantic-pull-request` → v6.1.1
- `anthropics/claude-code-action` → v1.0.133
- `kosli-dev/setup-cli-action` → v5.0.1
- `anchore/sbom-action` → v0.24.0
- `crazy-max/ghaction-import-gpg` → v7.0.0
- `goreleaser/goreleaser-action` → v7.2.2
- `peter-evans/create-pull-request` → v8.1.1
- `kosli-dev/reusable-actions/slack-release-notify@main` pinned to current main SHA (no version tag available)

## Test plan
- [ ] CI workflow runs green on this PR