### PR TITLE
ci: pin setup-cli-action to @v5

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Kosli CLI
-        uses: kosli-dev/setup-cli-action@3f490a708eadc496b242045ee981344b3aec9a9a # v5.0.2
+        uses: kosli-dev/setup-cli-action@v5
         with:
           version: ${{ env.KOSLI_VERSION }}
 
@@ -63,7 +63,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Kosli CLI
-        uses: kosli-dev/setup-cli-action@3f490a708eadc496b242045ee981344b3aec9a9a # v5.0.2
+        uses: kosli-dev/setup-cli-action@v5
         with:
           version: ${{ env.KOSLI_VERSION }}
 
@@ -87,7 +87,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Kosli CLI
-        uses: kosli-dev/setup-cli-action@3f490a708eadc496b242045ee981344b3aec9a9a # v5.0.2
+        uses: kosli-dev/setup-cli-action@v5
         with:
           version: ${{ env.KOSLI_VERSION }}
 
@@ -163,7 +163,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Kosli CLI
-        uses: kosli-dev/setup-cli-action@3f490a708eadc496b242045ee981344b3aec9a9a # v5.0.2
+        uses: kosli-dev/setup-cli-action@v5
         with:
           version: ${{ env.KOSLI_VERSION }}
 


### PR DESCRIPTION
Bumps `setup-cli-action` from the SHA-pinned `@v5.0.2` to the rolling `@v5` tag (currently **v5.1.0**), consolidating onto the v5 line. v5 also adds major/minor version pinning for the Kosli CLI via the `version:` input.

Part of an org-wide bump of `setup-cli-action` consumers to `@v5`.

Tracking: kosli-dev/server#5996