### PR TITLE
ci: install Terraform CLI before docs and acceptance tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,6 +37,12 @@ jobs:
       - name: Verify Go version
         run: go version
 
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
+        with:
+          terraform_version: "~1.10.0"
+          terraform_wrapper: false
+
       - name: Check code formatting
         run: |
           make fmt

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -129,6 +129,12 @@ jobs:
             --compliant=${{ steps.unit_tests.outcome == 'success' }} \
             --description "Unit tests"
 
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
+        with:
+          terraform_version: "~1.10.0"
+          terraform_wrapper: false
+
       - name: Run acceptance tests
         id: acceptance_tests
         continue-on-error: true


### PR DESCRIPTION
The PR-checks and main-pipeline test jobs ran 'make docs' and 'make testacc' without a Terraform binary on PATH. The plugin-testing framework and `tfplugindocs` then auto-downloaded the CLI from `checkpoint/releases.hashicorp.com` at runtime, which failed with a transient 502 from HashiCorp's CDN.

Add the `hashicorp/setup-terraform` step (pinned to v4.0.1, the same version already used by the validate-examples jobs) so Terraform is present on PATH and the per-run download is skipped.