### PR TITLE
refactor(client): route multipart requests through `doRequest` via `MultipartMarshaler`

### DIFF
--- a/adrs/002-api-client-architecture.md
+++ b/adrs/002-api-client-architecture.md
@@ -319,8 +319,8 @@ Some Kosli endpoints expect `multipart/form-data` (file uploads) rather than JSO
 Originally these methods bypassed `doRequest()` and built raw HTTP requests,
 duplicating auth header setup, URL construction, and error handling ([#198](https://github.com/kosli-dev/terraform-provider-kosli/issues/198)).
 
-The Client now follows the dispatch pattern used by SDK generators (OpenAI Go SDK,
-Cloudflare Go SDK, Speakeasy): request types that need multipart encoding implement
+The Client now follows the dispatch pattern used by SDK generators (Cloudflare Go
+SDK, Speakeasy): request types that need multipart encoding implement
 the `MultipartMarshaler` interface, and `doRequest()` type-switches on the body
 before falling back to JSON:
 

--- a/adrs/002-api-client-architecture.md
+++ b/adrs/002-api-client-architecture.md
@@ -293,40 +293,15 @@ func (at *CustomAttestationType) fromAPIFormat() {
 
 ```go
 func (c *Client) CreateCustomAttestationType(ctx context.Context, req *CreateCustomAttestationTypeRequest) error {
-    // Transform to API format
-    data := req.toAPIFormat()
-
-    // Create multipart form body
-    body, contentType, err := createMultipartRequest(data, req.Schema)
-    if err != nil {
-        return fmt.Errorf("failed to create multipart request: %w", err)
-    }
-
     // Build path
     path := fmt.Sprintf("/custom-attestation-types/%s", c.Organization())
 
-    // Create custom HTTP request (not using client.Post because it sends JSON)
-    httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.apiURL+path, body)
+    // doRequest dispatches to MarshalMultipart for the multipart body
+    resp, err := c.Post(ctx, path, req)
     if err != nil {
-        return fmt.Errorf("failed to create HTTP request: %w", err)
-    }
-
-    // Set headers manually
-    httpReq.Header.Set("Content-Type", contentType)
-    httpReq.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.apiToken))
-    httpReq.Header.Set("User-Agent", c.userAgent)
-
-    // Execute request
-    resp, err := c.httpClient.Do(httpReq)
-    if err != nil {
-        return fmt.Errorf("failed to execute request: %w", err)
+        return err
     }
     defer resp.Body.Close()
-
-    // Handle errors
-    if resp.StatusCode >= 400 {
-        return parseErrorResponse(resp)
-    }
 
     // Verify 201 status
     if resp.StatusCode != http.StatusCreated {
@@ -337,6 +312,32 @@ func (c *Client) CreateCustomAttestationType(ctx context.Context, req *CreateCus
     return nil
 }
 ```
+
+### Multipart Requests (Update, 2026-07)
+
+Some Kosli endpoints expect `multipart/form-data` (file uploads) rather than JSON.
+Originally these methods bypassed `doRequest()` and built raw HTTP requests,
+duplicating auth header setup, URL construction, and error handling ([#198](https://github.com/kosli-dev/terraform-provider-kosli/issues/198)).
+
+The Client now follows the dispatch pattern used by SDK generators (OpenAI Go SDK,
+Cloudflare Go SDK, Speakeasy): request types that need multipart encoding implement
+the `MultipartMarshaler` interface, and `doRequest()` type-switches on the body
+before falling back to JSON:
+
+```go
+// MultipartMarshaler is implemented by request types that require
+// multipart/form-data encoding (e.g., file uploads).
+type MultipartMarshaler interface {
+    MarshalMultipart() (body io.Reader, contentType string, err error)
+}
+```
+
+`CreateCustomAttestationTypeRequest`, `CreatePolicyRequest`, and `CreateFlowRequest`
+implement this interface. All requests — JSON and multipart — flow through
+`doRequest()`, so auth, error handling, retries, and any future middleware live in
+one place, and the Client keeps the shape required for eventual extraction into a
+standalone Kosli Go SDK. Adding a new multipart endpoint only requires implementing
+`MarshalMultipart()` on the request struct.
 
 ---
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -270,6 +270,11 @@ func (c *Client) Delete(ctx context.Context, path string) (*http.Response, error
 // multipart/form-data encoding (e.g., file uploads). doRequest dispatches
 // on this interface before falling back to JSON encoding, so multipart
 // requests share the same auth, error handling, and retry path as JSON ones.
+//
+// Implementations must tolerate a nil receiver by returning an error: a
+// typed-nil pointer wrapped in a non-nil interface skips doRequest's nil
+// case and reaches MarshalMultipart, where a missing guard would panic
+// and crash the provider (see TestClient_Put_TypedNilMultipartBody).
 type MultipartMarshaler interface {
 	MarshalMultipart() (body io.Reader, contentType string, err error)
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -275,6 +275,13 @@ func (c *Client) Delete(ctx context.Context, path string) (*http.Response, error
 // typed-nil pointer wrapped in a non-nil interface skips doRequest's nil
 // case and reaches MarshalMultipart, where a missing guard would panic
 // and crash the provider (see TestClient_Put_TypedNilMultipartBody).
+//
+// The returned body may be any reader: the retry layer buffers request
+// bodies fully in memory before sending (go-retryablehttp's FromRequest),
+// so retries replay the body intact regardless of the concrete reader
+// type (see TestClient_Post_MultipartRetryReplay*). The flip side is that
+// bodies are always held in memory — do not stream unbounded content
+// through this interface.
 type MultipartMarshaler interface {
 	MarshalMultipart() (body io.Reader, contentType string, err error)
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -266,19 +266,38 @@ func (c *Client) Delete(ctx context.Context, path string) (*http.Response, error
 	return c.doRequest(ctx, http.MethodDelete, path, nil)
 }
 
+// MultipartMarshaler is implemented by request types that require
+// multipart/form-data encoding (e.g., file uploads). doRequest dispatches
+// on this interface before falling back to JSON encoding, so multipart
+// requests share the same auth, error handling, and retry path as JSON ones.
+type MultipartMarshaler interface {
+	MarshalMultipart() (body io.Reader, contentType string, err error)
+}
+
 // doRequest performs an HTTP request with authentication and error handling.
 func (c *Client) doRequest(ctx context.Context, method, path string, body any) (*http.Response, error) {
 	// Build full URL
 	url := c.apiURL + path
 
-	// Marshal body to JSON if provided
+	// Encode the body: multipart if the request type opts in, JSON otherwise
 	var bodyReader io.Reader
-	if body != nil {
+	var contentType string
+	switch v := body.(type) {
+	case nil:
+		// No body
+	case MultipartMarshaler:
+		var err error
+		bodyReader, contentType, err = v.MarshalMultipart()
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal multipart body: %w", err)
+		}
+	default:
 		jsonBody, err := json.Marshal(body)
 		if err != nil {
 			return nil, fmt.Errorf("failed to marshal request body: %w", err)
 		}
 		bodyReader = bytes.NewReader(jsonBody)
+		contentType = "application/json"
 	}
 
 	// Create HTTP request
@@ -290,8 +309,8 @@ func (c *Client) doRequest(ctx context.Context, method, path string, body any) (
 	// Add headers
 	req.Header.Set("Authorization", "Bearer "+c.apiToken)
 	req.Header.Set("User-Agent", c.userAgent)
-	if body != nil {
-		req.Header.Set("Content-Type", "application/json")
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
 	}
 
 	// Execute request

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -399,6 +399,56 @@ func TestClient_Post_Multipart(t *testing.T) {
 	}
 }
 
+// TestClient_Post_MultipartRetryReplay tests that a multipart body is re-sent
+// intact when the retry layer replays the request after a 5xx response.
+func TestClient_Post_MultipartRetryReplay(t *testing.T) {
+	var bodies []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("failed to read request body: %v", err)
+		}
+		bodies = append(bodies, string(raw))
+		if len(bodies) == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer server.Close()
+
+	client, err := NewClient("test-token", "test-org",
+		WithBaseURL(server.URL),
+		WithAPIPath(""),
+		WithRetryPolicy(2, 1*time.Millisecond, 5*time.Millisecond),
+	)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	resp, err := client.Post(context.Background(), "/test-path", &testMultipartRequest{field: "value"})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Errorf("expected status 201, got %d", resp.StatusCode)
+	}
+	if len(bodies) != 2 {
+		t.Fatalf("expected 2 requests (original + retry), got %d", len(bodies))
+	}
+	if bodies[0] == "" {
+		t.Fatal("first request body is empty")
+	}
+	if bodies[0] != bodies[1] {
+		t.Errorf("retried body differs from original:\nfirst:  %q\nsecond: %q", bodies[0], bodies[1])
+	}
+	if !strings.Contains(bodies[1], `name="field"`) || !strings.Contains(bodies[1], "value") {
+		t.Errorf("retried body missing multipart field: %q", bodies[1])
+	}
+}
+
 // TestClient_Post_MultipartMarshalError tests that MarshalMultipart errors are surfaced.
 func TestClient_Post_MultipartMarshalError(t *testing.T) {
 	client, err := NewClient("test-token", "test-org")

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -449,6 +449,79 @@ func TestClient_Post_MultipartRetryReplay(t *testing.T) {
 	}
 }
 
+// onceReader hides the concrete type of the wrapped reader: no Seek, no Len,
+// not one of the buffer types net/http or retryablehttp special-case. It
+// simulates a streaming MarshalMultipart implementation.
+type onceReader struct{ r io.Reader }
+
+func (o *onceReader) Read(p []byte) (int, error) { return o.r.Read(p) }
+
+// testStreamingMultipartRequest returns a non-rewindable reader from
+// MarshalMultipart.
+type testStreamingMultipartRequest struct{ field string }
+
+func (r *testStreamingMultipartRequest) MarshalMultipart() (io.Reader, string, error) {
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+	if err := writer.WriteField("field", r.field); err != nil {
+		return nil, "", err
+	}
+	contentType := writer.FormDataContentType()
+	if err := writer.Close(); err != nil {
+		return nil, "", err
+	}
+	return &onceReader{&buf}, contentType, nil
+}
+
+// TestClient_Post_MultipartRetryReplay_StreamingReader tests that the retry
+// replay guarantee does not depend on MarshalMultipart returning a rewindable
+// reader type: the retry layer buffers any reader in memory before sending
+// (go-retryablehttp FromRequest), so even a streaming body is re-sent intact.
+func TestClient_Post_MultipartRetryReplay_StreamingReader(t *testing.T) {
+	var bodies []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("failed to read request body: %v", err)
+		}
+		bodies = append(bodies, string(raw))
+		if len(bodies) == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer server.Close()
+
+	client, err := NewClient("test-token", "test-org",
+		WithBaseURL(server.URL),
+		WithAPIPath(""),
+		WithRetryPolicy(2, 1*time.Millisecond, 5*time.Millisecond),
+	)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	resp, err := client.Post(context.Background(), "/test-path", &testStreamingMultipartRequest{field: "value"})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	defer resp.Body.Close()
+
+	if len(bodies) != 2 {
+		t.Fatalf("expected 2 requests (original + retry), got %d", len(bodies))
+	}
+	if bodies[0] == "" || bodies[1] == "" {
+		t.Fatalf("expected non-empty bodies, got first %d bytes, second %d bytes", len(bodies[0]), len(bodies[1]))
+	}
+	if bodies[0] != bodies[1] {
+		t.Errorf("retried body differs from original:\nfirst:  %q\nsecond: %q", bodies[0], bodies[1])
+	}
+	if !strings.Contains(bodies[1], `name="field"`) || !strings.Contains(bodies[1], "value") {
+		t.Errorf("retried body missing multipart field: %q", bodies[1])
+	}
+}
+
 // TestClient_Post_MultipartMarshalError tests that MarshalMultipart errors are surfaced.
 func TestClient_Post_MultipartMarshalError(t *testing.T) {
 	client, err := NewClient("test-token", "test-org")

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -1,9 +1,12 @@
 package client
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -322,6 +325,127 @@ func TestClient_Post_Success(t *testing.T) {
 
 	if resp.StatusCode != http.StatusCreated {
 		t.Errorf("expected status 201, got %d", resp.StatusCode)
+	}
+}
+
+// testMultipartRequest implements MultipartMarshaler for testing doRequest dispatch.
+type testMultipartRequest struct {
+	field string
+	err   error
+}
+
+func (r *testMultipartRequest) MarshalMultipart() (io.Reader, string, error) {
+	if r.err != nil {
+		return nil, "", r.err
+	}
+
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+	if err := writer.WriteField("field", r.field); err != nil {
+		return nil, "", err
+	}
+	contentType := writer.FormDataContentType()
+	if err := writer.Close(); err != nil {
+		return nil, "", err
+	}
+	return &buf, contentType, nil
+}
+
+// TestClient_Post_Multipart tests that doRequest dispatches bodies implementing
+// MultipartMarshaler to multipart/form-data encoding instead of JSON.
+func TestClient_Post_Multipart(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+
+		if ct := r.Header.Get("Content-Type"); !strings.HasPrefix(ct, "multipart/form-data") {
+			t.Errorf("expected multipart/form-data Content-Type, got %q", ct)
+		}
+
+		// Auth headers must be set on multipart requests too
+		if auth := r.Header.Get("Authorization"); auth != "Bearer test-token" {
+			t.Errorf("expected Authorization 'Bearer test-token', got %q", auth)
+		}
+
+		if err := r.ParseMultipartForm(10 << 20); err != nil {
+			t.Fatalf("failed to parse multipart form: %v", err)
+		}
+		if got := r.FormValue("field"); got != "value" {
+			t.Errorf("expected field 'value', got %q", got)
+		}
+
+		w.WriteHeader(http.StatusCreated)
+		w.Write([]byte(`"OK"`))
+	}))
+	defer server.Close()
+
+	client, err := NewClient("test-token", "test-org",
+		WithBaseURL(server.URL),
+		WithAPIPath(""),
+	)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	resp, err := client.Post(context.Background(), "/test-path", &testMultipartRequest{field: "value"})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Errorf("expected status 201, got %d", resp.StatusCode)
+	}
+}
+
+// TestClient_Post_MultipartMarshalError tests that MarshalMultipart errors are surfaced.
+func TestClient_Post_MultipartMarshalError(t *testing.T) {
+	client, err := NewClient("test-token", "test-org")
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	_, err = client.Post(context.Background(), "/test-path", &testMultipartRequest{err: errors.New("boom")})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to marshal multipart body") {
+		t.Errorf("expected multipart marshal error, got %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "boom") {
+		t.Errorf("expected wrapped error 'boom', got %q", err.Error())
+	}
+}
+
+// TestClient_Put_TypedNilMultipartBody tests that a typed-nil pointer
+// implementing MultipartMarshaler surfaces as an error from doRequest
+// instead of a panic (which would crash the provider plugin process).
+func TestClient_Put_TypedNilMultipartBody(t *testing.T) {
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client, err := NewClient("test-token", "test-org",
+		WithBaseURL(server.URL),
+		WithAPIPath(""),
+	)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	_, err = client.Put(context.Background(), "/test-path", (*CreateFlowRequest)(nil))
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to marshal multipart body") {
+		t.Errorf("expected multipart marshal error, got %q", err.Error())
+	}
+	if requestCount != 0 {
+		t.Errorf("expected no request to be sent, got %d", requestCount)
 	}
 }
 

--- a/pkg/client/custom_attestation_types.go
+++ b/pkg/client/custom_attestation_types.go
@@ -151,7 +151,9 @@ func (c *Client) CreateCustomAttestationType(ctx context.Context, req *CreateCus
 	}
 	defer resp.Body.Close()
 
-	// Verify 201 status
+	// This POST's API contract is exactly 201, even for existing names
+	// (a new version is created). Deliberately stricter than CreatePolicy
+	// and CreateFlow, whose PUT upserts legitimately return 200 or 201.
 	if resp.StatusCode != http.StatusCreated {
 		return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
 	}

--- a/pkg/client/custom_attestation_types.go
+++ b/pkg/client/custom_attestation_types.go
@@ -99,13 +99,18 @@ func (at *CustomAttestationType) fromAPIFormat() error {
 	return nil
 }
 
-// createMultipartRequest builds multipart/form-data request for POST.
-func createMultipartRequest(data map[string]any, schema string) (io.Reader, string, error) {
+// MarshalMultipart implements MultipartMarshaler. It encodes the request as
+// multipart/form-data with a data_json field and an optional type_schema file.
+func (req *CreateCustomAttestationTypeRequest) MarshalMultipart() (io.Reader, string, error) {
+	if req == nil {
+		return nil, "", fmt.Errorf("nil request")
+	}
+
 	var buf bytes.Buffer
 	writer := multipart.NewWriter(&buf)
 
 	// Add data_json field
-	dataJSON, err := json.Marshal(data)
+	dataJSON, err := json.Marshal(req.toAPIFormat())
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to marshal data: %w", err)
 	}
@@ -114,12 +119,12 @@ func createMultipartRequest(data map[string]any, schema string) (io.Reader, stri
 	}
 
 	// Add type_schema field if provided
-	if schema != "" {
+	if req.Schema != "" {
 		part, err := writer.CreateFormFile("type_schema", "schema.json")
 		if err != nil {
 			return nil, "", fmt.Errorf("failed to create type_schema field: %w", err)
 		}
-		if _, err := part.Write([]byte(schema)); err != nil {
+		if _, err := part.Write([]byte(req.Schema)); err != nil {
 			return nil, "", fmt.Errorf("failed to write type_schema content: %w", err)
 		}
 	}
@@ -136,40 +141,15 @@ func createMultipartRequest(data map[string]any, schema string) (io.Reader, stri
 // Per ADR 002, this method is a thin wrapper that returns what the API returns.
 // The API returns "OK" (201 Created), not the created object.
 func (c *Client) CreateCustomAttestationType(ctx context.Context, req *CreateCustomAttestationTypeRequest) error {
-	// Build API-format data
-	data := req.toAPIFormat()
-
-	// Create multipart form body
-	body, contentType, err := createMultipartRequest(data, req.Schema)
-	if err != nil {
-		return fmt.Errorf("failed to create multipart request: %w", err)
-	}
-
 	// Build path
 	path := fmt.Sprintf("/custom-attestation-types/%s", c.Organization())
 
-	// Create custom HTTP request (not using client.Post because it sends JSON)
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.apiURL+path, body)
+	// doRequest dispatches to MarshalMultipart for the multipart body
+	resp, err := c.Post(ctx, path, req)
 	if err != nil {
-		return fmt.Errorf("failed to create HTTP request: %w", err)
-	}
-
-	// Set headers manually
-	httpReq.Header.Set("Content-Type", contentType)
-	httpReq.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.apiToken))
-	httpReq.Header.Set("User-Agent", c.userAgent)
-
-	// Execute request
-	resp, err := c.httpClient.Do(httpReq)
-	if err != nil {
-		return fmt.Errorf("failed to execute request: %w", err)
+		return err
 	}
 	defer resp.Body.Close()
-
-	// Handle errors
-	if resp.StatusCode >= 400 {
-		return parseErrorResponse(resp)
-	}
 
 	// Verify 201 status
 	if resp.StatusCode != http.StatusCreated {

--- a/pkg/client/custom_attestation_types_test.go
+++ b/pkg/client/custom_attestation_types_test.go
@@ -529,6 +529,16 @@ func TestArchiveCustomAttestationType_NotFound(t *testing.T) {
 	}
 }
 
+// TestCreateCustomAttestationTypeRequest_MarshalMultipart_Nil tests that a nil
+// request returns an error instead of panicking.
+func TestCreateCustomAttestationTypeRequest_MarshalMultipart_Nil(t *testing.T) {
+	var req *CreateCustomAttestationTypeRequest
+	_, _, err := req.MarshalMultipart()
+	if err == nil {
+		t.Fatal("expected error for nil request, got nil")
+	}
+}
+
 // TestTransformation_ToAPIFormat tests toAPIFormat transformation
 func TestTransformation_ToAPIFormat(t *testing.T) {
 	req := &CreateCustomAttestationTypeRequest{

--- a/pkg/client/flows.go
+++ b/pkg/client/flows.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"mime/multipart"
-	"net/http"
 )
 
 // Flow represents a Kosli flow as returned by the API.
@@ -27,11 +26,21 @@ type CreateFlowRequest struct {
 	Template    string // Optional YAML template content; when empty, template_file is omitted from the multipart request
 }
 
-// createFlowMultipartRequest builds a multipart/form-data body for flow creation.
-// Fields:
+// MarshalMultipart implements MultipartMarshaler. It encodes the request as
+// multipart/form-data with:
 //   - data_json: JSON with name, description, visibility
-//   - template_file: YAML template content (only included when template is non-empty)
-func createFlowMultipartRequest(payload map[string]any, template string) (io.Reader, string, error) {
+//   - template_file: YAML template content (only included when Template is non-empty)
+func (req *CreateFlowRequest) MarshalMultipart() (io.Reader, string, error) {
+	if req == nil {
+		return nil, "", fmt.Errorf("nil request")
+	}
+
+	payload := map[string]any{
+		"name":        req.Name,
+		"description": req.Description,
+		"visibility":  req.Visibility,
+	}
+
 	var buf bytes.Buffer
 	writer := multipart.NewWriter(&buf)
 
@@ -45,12 +54,12 @@ func createFlowMultipartRequest(payload map[string]any, template string) (io.Rea
 	}
 
 	// Add template_file field only when template is provided
-	if template != "" {
+	if req.Template != "" {
 		part, err := writer.CreateFormFile("template_file", "template.yml")
 		if err != nil {
 			return nil, "", fmt.Errorf("failed to create template_file field: %w", err)
 		}
-		if _, err := part.Write([]byte(template)); err != nil {
+		if _, err := part.Write([]byte(req.Template)); err != nil {
 			return nil, "", fmt.Errorf("failed to write template_file content: %w", err)
 		}
 	}
@@ -67,37 +76,14 @@ func createFlowMultipartRequest(payload map[string]any, template string) (io.Rea
 // The request always includes a data_json field with flow metadata (name, description, visibility).
 // The template_file field is conditionally included when a YAML template is provided.
 func (c *Client) CreateFlow(ctx context.Context, req *CreateFlowRequest) error {
-	payload := map[string]any{
-		"name":        req.Name,
-		"description": req.Description,
-		"visibility":  req.Visibility,
-	}
-
 	path := fmt.Sprintf("/flows/%s/template_file", c.Organization())
 
-	body, contentType, err := createFlowMultipartRequest(payload, req.Template)
+	// doRequest dispatches to MarshalMultipart for the multipart body
+	resp, err := c.Put(ctx, path, req)
 	if err != nil {
-		return fmt.Errorf("failed to create multipart request: %w", err)
-	}
-
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPut, c.apiURL+path, body)
-	if err != nil {
-		return fmt.Errorf("failed to create HTTP request: %w", err)
-	}
-
-	httpReq.Header.Set("Content-Type", contentType)
-	httpReq.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.apiToken))
-	httpReq.Header.Set("User-Agent", c.userAgent)
-
-	resp, err := c.httpClient.Do(httpReq)
-	if err != nil {
-		return fmt.Errorf("failed to execute request: %w", err)
+		return err
 	}
 	defer resp.Body.Close()
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return parseErrorResponse(resp)
-	}
 
 	return nil
 }

--- a/pkg/client/flows_test.go
+++ b/pkg/client/flows_test.go
@@ -1,0 +1,283 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestCreateFlow_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Errorf("expected PUT, got %s", r.Method)
+		}
+		if !strings.Contains(r.URL.Path, "/flows/test-org/template_file") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+
+		ct := r.Header.Get("Content-Type")
+		if !strings.HasPrefix(ct, "multipart/form-data") {
+			t.Errorf("expected multipart/form-data, got %s", ct)
+		}
+
+		if err := r.ParseMultipartForm(10 << 20); err != nil {
+			t.Fatalf("failed to parse multipart form: %v", err)
+		}
+
+		// Verify data_json field
+		dataJSON := r.FormValue("data_json")
+		if dataJSON == "" {
+			t.Error("data_json field is empty")
+		}
+		var data map[string]any
+		if err := json.Unmarshal([]byte(dataJSON), &data); err != nil {
+			t.Fatalf("failed to unmarshal data_json: %v", err)
+		}
+		if data["name"] != "test-flow" {
+			t.Errorf("expected name 'test-flow', got %v", data["name"])
+		}
+		if data["visibility"] != "private" {
+			t.Errorf("expected visibility 'private', got %v", data["visibility"])
+		}
+
+		// Verify template_file field
+		_, fileHeader, err := r.FormFile("template_file")
+		if err != nil {
+			t.Errorf("failed to get template_file: %v", err)
+		}
+		if fileHeader.Filename != "template.yml" {
+			t.Errorf("expected filename 'template.yml', got %s", fileHeader.Filename)
+		}
+
+		w.WriteHeader(http.StatusCreated)
+		w.Write([]byte(`"created"`))
+	}))
+	defer server.Close()
+
+	c, err := NewClient("test-token", "test-org",
+		WithBaseURL(server.URL),
+		WithAPIPath(""),
+	)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	err = c.CreateFlow(context.Background(), &CreateFlowRequest{
+		Name:        "test-flow",
+		Description: "test description",
+		Visibility:  "private",
+		Template:    "version: 1\ntrail:\n  attestations: []\n",
+	})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestCreateFlow_NoTemplate(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseMultipartForm(10 << 20); err != nil {
+			t.Fatalf("failed to parse multipart form: %v", err)
+		}
+
+		// template_file should be omitted when Template is empty
+		_, _, err := r.FormFile("template_file")
+		if err == nil {
+			t.Error("expected no template_file field, but found one")
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	c, err := NewClient("test-token", "test-org",
+		WithBaseURL(server.URL),
+		WithAPIPath(""),
+	)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	err = c.CreateFlow(context.Background(), &CreateFlowRequest{
+		Name:       "test-flow",
+		Visibility: "private",
+	})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestCreateFlow_BadRequest(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{"error": "invalid request"}`))
+	}))
+	defer server.Close()
+
+	c, err := NewClient("test-token", "test-org",
+		WithBaseURL(server.URL),
+		WithAPIPath(""),
+	)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	err = c.CreateFlow(context.Background(), &CreateFlowRequest{Name: ""})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !IsBadRequest(err) {
+		t.Errorf("expected bad request error, got %v", err)
+	}
+}
+
+func TestGetFlow_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if !strings.Contains(r.URL.Path, "/flows/test-org/test-flow") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{
+			"name": "test-flow",
+			"description": "test description",
+			"visibility": "private",
+			"template": "",
+			"tags": {}
+		}`))
+	}))
+	defer server.Close()
+
+	c, err := NewClient("test-token", "test-org",
+		WithBaseURL(server.URL),
+		WithAPIPath(""),
+	)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	flow, err := c.GetFlow(context.Background(), "test-flow")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if flow.Name != "test-flow" {
+		t.Errorf("expected name 'test-flow', got %q", flow.Name)
+	}
+	if flow.Visibility != "private" {
+		t.Errorf("expected visibility 'private', got %q", flow.Visibility)
+	}
+}
+
+func TestGetFlow_NotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`{"message":"flow not found"}`))
+	}))
+	defer server.Close()
+
+	c, err := NewClient("test-token", "test-org",
+		WithBaseURL(server.URL),
+		WithAPIPath(""),
+	)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	_, err = c.GetFlow(context.Background(), "nonexistent")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !IsNotFound(err) {
+		t.Errorf("expected not found error, got %v", err)
+	}
+}
+
+func TestListFlows_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if !strings.Contains(r.URL.Path, "/flows/test-org") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`[
+			{"name": "flow-a", "description": "First flow"},
+			{"name": "flow-b", "description": "Second flow"}
+		]`))
+	}))
+	defer server.Close()
+
+	c, err := NewClient("test-token", "test-org",
+		WithBaseURL(server.URL),
+		WithAPIPath(""),
+	)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	flows, err := c.ListFlows(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(flows) != 2 {
+		t.Fatalf("expected 2 flows, got %d", len(flows))
+	}
+	if flows[0].Name != "flow-a" {
+		t.Errorf("expected first flow name 'flow-a', got %q", flows[0].Name)
+	}
+}
+
+func TestArchiveFlow_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Errorf("expected PUT, got %s", r.Method)
+		}
+		if !strings.Contains(r.URL.Path, "/flows/test-org/test-flow/archive") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	c, err := NewClient("test-token", "test-org",
+		WithBaseURL(server.URL),
+		WithAPIPath(""),
+	)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	err = c.ArchiveFlow(context.Background(), "test-flow")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// TestCreateFlowRequest_MarshalMultipart_Nil tests that a nil request
+// returns an error instead of panicking.
+func TestCreateFlowRequest_MarshalMultipart_Nil(t *testing.T) {
+	var req *CreateFlowRequest
+	_, _, err := req.MarshalMultipart()
+	if err == nil {
+		t.Fatal("expected error for nil request, got nil")
+	}
+}
+
+func TestCreateFlowRequest_MarshalMultipart_NoTemplate(t *testing.T) {
+	req := &CreateFlowRequest{Name: "test", Visibility: "private"}
+	body, ct, err := req.MarshalMultipart()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.HasPrefix(ct, "multipart/form-data") {
+		t.Errorf("expected multipart/form-data content type, got %s", ct)
+	}
+	if body == nil {
+		t.Error("expected non-nil body")
+	}
+}

--- a/pkg/client/policies.go
+++ b/pkg/client/policies.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"log"
 	"mime/multipart"
-	"net/http"
 )
 
 // Policy represents a Kosli policy as returned by the API.
@@ -35,11 +34,15 @@ type CreatePolicyRequest struct {
 	Content     string // YAML policy content
 }
 
-// CreatePolicy creates or updates a policy.
-// The API returns 201 for new policies and 200 for updates.
-// Per ADR 002, this method is a thin wrapper; call GetPolicy to read state after.
-func (c *Client) CreatePolicy(ctx context.Context, req *CreatePolicyRequest) error {
-	// Build payload JSON
+// MarshalMultipart implements MultipartMarshaler. It encodes the request as
+// multipart/form-data with:
+//   - "payload": JSON with name, description, type, comment
+//   - "policy_file": YAML content as a file upload (only when Content is non-empty)
+func (req *CreatePolicyRequest) MarshalMultipart() (io.Reader, string, error) {
+	if req == nil {
+		return nil, "", fmt.Errorf("nil request")
+	}
+
 	payload := map[string]any{
 		"name":        req.Name,
 		"description": req.Description,
@@ -47,35 +50,50 @@ func (c *Client) CreatePolicy(ctx context.Context, req *CreatePolicyRequest) err
 		"comment":     req.Comment,
 	}
 
-	// Build multipart body
-	body, contentType, err := createPolicyMultipartRequest(payload, req.Content)
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+
+	// Add payload field
+	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		return fmt.Errorf("failed to create multipart request: %w", err)
+		return nil, "", fmt.Errorf("failed to marshal payload: %w", err)
+	}
+	if err := writer.WriteField("payload", string(payloadJSON)); err != nil {
+		return nil, "", fmt.Errorf("failed to write payload field: %w", err)
 	}
 
+	// Add policy_file field if content is provided
+	if req.Content != "" {
+		part, err := writer.CreateFormFile("policy_file", "policy.yaml")
+		if err != nil {
+			return nil, "", fmt.Errorf("failed to create policy_file field: %w", err)
+		}
+		if _, err := part.Write([]byte(req.Content)); err != nil {
+			return nil, "", fmt.Errorf("failed to write policy_file content: %w", err)
+		}
+	}
+
+	contentType := writer.FormDataContentType()
+	if err := writer.Close(); err != nil {
+		return nil, "", fmt.Errorf("failed to close multipart writer: %w", err)
+	}
+
+	return &buf, contentType, nil
+}
+
+// CreatePolicy creates or updates a policy.
+// The API returns 201 for new policies and 200 for updates.
+// Per ADR 002, this method is a thin wrapper; call GetPolicy to read state after.
+func (c *Client) CreatePolicy(ctx context.Context, req *CreatePolicyRequest) error {
 	// Build path: PUT /api/v2/policies/{org}
 	path := fmt.Sprintf("/policies/%s", c.Organization())
 
-	// Create custom HTTP request (multipart, not JSON)
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPut, c.apiURL+path, body)
+	// doRequest dispatches to MarshalMultipart for the multipart body
+	resp, err := c.Put(ctx, path, req)
 	if err != nil {
-		return fmt.Errorf("failed to create HTTP request: %w", err)
-	}
-
-	// doRequest only supports JSON bodies; set auth/UA headers manually for this multipart request.
-	httpReq.Header.Set("Content-Type", contentType)
-	httpReq.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.apiToken))
-	httpReq.Header.Set("User-Agent", c.userAgent)
-
-	resp, err := c.httpClient.Do(httpReq)
-	if err != nil {
-		return fmt.Errorf("failed to execute request: %w", err)
+		return err
 	}
 	defer resp.Body.Close()
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return parseErrorResponse(resp)
-	}
 
 	return nil
 }
@@ -119,40 +137,4 @@ func (c *Client) ListPolicies(ctx context.Context) ([]Policy, error) {
 	}
 
 	return result, nil
-}
-
-// createPolicyMultipartRequest builds a multipart/form-data body for policy create/update.
-// Fields:
-//   - "payload": JSON with name, description, type, comment
-//   - "policy_file": YAML content as a file upload
-func createPolicyMultipartRequest(payload map[string]any, content string) (io.Reader, string, error) {
-	var buf bytes.Buffer
-	writer := multipart.NewWriter(&buf)
-
-	// Add payload field
-	payloadJSON, err := json.Marshal(payload)
-	if err != nil {
-		return nil, "", fmt.Errorf("failed to marshal payload: %w", err)
-	}
-	if err := writer.WriteField("payload", string(payloadJSON)); err != nil {
-		return nil, "", fmt.Errorf("failed to write payload field: %w", err)
-	}
-
-	// Add policy_file field if content is provided
-	if content != "" {
-		part, err := writer.CreateFormFile("policy_file", "policy.yaml")
-		if err != nil {
-			return nil, "", fmt.Errorf("failed to create policy_file field: %w", err)
-		}
-		if _, err := part.Write([]byte(content)); err != nil {
-			return nil, "", fmt.Errorf("failed to write policy_file content: %w", err)
-		}
-	}
-
-	contentType := writer.FormDataContentType()
-	if err := writer.Close(); err != nil {
-		return nil, "", fmt.Errorf("failed to close multipart writer: %w", err)
-	}
-
-	return &buf, contentType, nil
 }

--- a/pkg/client/policies.go
+++ b/pkg/client/policies.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"mime/multipart"
 )
 
@@ -106,17 +105,10 @@ func (c *Client) GetPolicy(ctx context.Context, name string) (*Policy, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read response body: %w", err)
-	}
-	log.Printf("[DEBUG] GetPolicy: received response for policy %q", name)
 
 	var result Policy
-	if err := json.Unmarshal(body, &result); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
+	if err := ParseResponse(resp, &result); err != nil {
+		return nil, err
 	}
 
 	return &result, nil

--- a/pkg/client/policies_test.go
+++ b/pkg/client/policies_test.go
@@ -248,9 +248,19 @@ func TestListPolicies_Empty(t *testing.T) {
 	}
 }
 
-func TestCreatePolicyMultipartRequest_NoContent(t *testing.T) {
-	payload := map[string]any{"name": "test", "type": "env"}
-	body, ct, err := createPolicyMultipartRequest(payload, "")
+// TestCreatePolicyRequest_MarshalMultipart_Nil tests that a nil request
+// returns an error instead of panicking.
+func TestCreatePolicyRequest_MarshalMultipart_Nil(t *testing.T) {
+	var req *CreatePolicyRequest
+	_, _, err := req.MarshalMultipart()
+	if err == nil {
+		t.Fatal("expected error for nil request, got nil")
+	}
+}
+
+func TestCreatePolicyRequest_MarshalMultipart_NoContent(t *testing.T) {
+	req := &CreatePolicyRequest{Name: "test"}
+	body, ct, err := req.MarshalMultipart()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
Three client functions (`CreateCustomAttestationType`, `CreatePolicy`, `CreateFlow`) bypassed `doRequest()` with raw HTTP requests because the client only supported JSON bodies, duplicating auth header setup, URL construction, and error handling.

Following the dispatch pattern used by SDK generators (Cloudflare and Speakeasy Go SDKs):

- Add a MultipartMarshaler interface; `doRequest()` type-switches on the body and dispatches to `MarshalMultipart()` before falling back to JSON
- Move the three standalone multipart builders onto their request structs as `MarshalMultipart()` implementations
- Collapse the bypassing functions to plain c.Post/c.Put calls

All requests now share a single code path for auth, error handling, and retries. Adds doRequest dispatch tests, a flows client test suite, and updates the stale ADR-002 example to the new pattern.

Closes #198