### PR TITLE
fix!: remove include_scaling from kosli_environment

### DIFF
--- a/docs/data-sources/environment.md
+++ b/docs/data-sources/environment.md
@@ -60,11 +60,6 @@ output "production_type" {
   value       = data.kosli_environment.production.type
 }
 
-output "production_includes_scaling" {
-  description = "Whether production environment includes scaling events"
-  value       = data.kosli_environment.production.include_scaling
-}
-
 # Access tags applied to the environment
 output "production_tags" {
   description = "Tags applied to the production environment"
@@ -117,7 +112,6 @@ Data sources provide read-only access to environment metadata. To modify environ
 ### Read-Only
 
 - `description` (String) The description of the environment.
-- `include_scaling` (Boolean) Whether the environment includes scaling events in snapshots.
 - `last_modified_at` (Number) Unix timestamp (with fractional seconds) of when the environment was last modified.
 - `last_reported_at` (Number) Unix timestamp (with fractional seconds) of when the environment was last reported. May be null if never reported.
 - `tags` (Map of String) Key-value pairs tagging the environment.

--- a/docs/resources/environment.md
+++ b/docs/resources/environment.md
@@ -45,12 +45,11 @@ resource "kosli_environment" "production_k8s" {
   description = "Production Kubernetes cluster"
 }
 
-# ECS environment with scaling
+# ECS environment
 resource "kosli_environment" "staging_ecs" {
-  name            = "staging-ecs"
-  type            = "ECS"
-  description     = "Staging ECS cluster"
-  include_scaling = true
+  name        = "staging-ecs"
+  type        = "ECS"
+  description = "Staging ECS cluster"
 }
 
 # S3 environment
@@ -68,10 +67,9 @@ resource "kosli_environment" "local_docker" {
 
 # Server environment
 resource "kosli_environment" "production_servers" {
-  name            = "production-servers"
-  type            = "server"
-  description     = "Production bare-metal servers"
-  include_scaling = false
+  name        = "production-servers"
+  type        = "server"
+  description = "Production bare-metal servers"
 }
 
 # Lambda environment
@@ -105,12 +103,6 @@ The `type` attribute must be one of the following physical environment types:
 - `server` - Bare-metal or VM servers
 - `lambda` - AWS Lambda functions
 
-## Configuration Options
-
-### Include Scaling
-
-The `include_scaling` attribute (default: `false`) determines whether scaling events in the environment should be tracked. This is useful for environments with auto-scaling where you want to monitor scale-up and scale-down events.
-
 ## Import
 
 Environments can be imported using their name:
@@ -141,5 +133,4 @@ For querying environment metadata such as `last_modified_at` and `last_reported_
 ### Optional
 
 - `description` (String) Description of the environment. Explains the purpose and characteristics of this deployment target.
-- `include_scaling` (Boolean) Whether to include scaling information when reporting environment snapshots. Defaults to `false`.
 - `tags` (Map of String) Key-value pairs to tag the environment.

--- a/examples/data-sources/kosli_environment/data-source.tf
+++ b/examples/data-sources/kosli_environment/data-source.tf
@@ -39,11 +39,6 @@ output "production_type" {
   value       = data.kosli_environment.production.type
 }
 
-output "production_includes_scaling" {
-  description = "Whether production environment includes scaling events"
-  value       = data.kosli_environment.production.include_scaling
-}
-
 # Access tags applied to the environment
 output "production_tags" {
   description = "Tags applied to the production environment"

--- a/examples/resources/kosli_environment/resource.tf
+++ b/examples/resources/kosli_environment/resource.tf
@@ -13,12 +13,11 @@ resource "kosli_environment" "production_k8s" {
   description = "Production Kubernetes cluster"
 }
 
-# ECS environment with scaling
+# ECS environment
 resource "kosli_environment" "staging_ecs" {
-  name            = "staging-ecs"
-  type            = "ECS"
-  description     = "Staging ECS cluster"
-  include_scaling = true
+  name        = "staging-ecs"
+  type        = "ECS"
+  description = "Staging ECS cluster"
 }
 
 # S3 environment
@@ -36,10 +35,9 @@ resource "kosli_environment" "local_docker" {
 
 # Server environment
 resource "kosli_environment" "production_servers" {
-  name            = "production-servers"
-  type            = "server"
-  description     = "Production bare-metal servers"
-  include_scaling = false
+  name        = "production-servers"
+  type        = "server"
+  description = "Production bare-metal servers"
 }
 
 # Lambda environment

--- a/internal/provider/data_source_environment.go
+++ b/internal/provider/data_source_environment.go
@@ -28,7 +28,6 @@ type environmentDataSourceModel struct {
 	Name           types.String  `tfsdk:"name"`
 	Type           types.String  `tfsdk:"type"`
 	Description    types.String  `tfsdk:"description"`
-	IncludeScaling types.Bool    `tfsdk:"include_scaling"`
 	LastModifiedAt types.Float64 `tfsdk:"last_modified_at"`
 	LastReportedAt types.Float64 `tfsdk:"last_reported_at"`
 	Tags           types.Map     `tfsdk:"tags"`
@@ -56,10 +55,6 @@ func (d *environmentDataSource) Schema(ctx context.Context, req datasource.Schem
 			"description": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "The description of the environment.",
-			},
-			"include_scaling": schema.BoolAttribute{
-				Computed:            true,
-				MarkdownDescription: "Whether the environment includes scaling events in snapshots.",
 			},
 			"last_modified_at": schema.Float64Attribute{
 				Computed:            true,
@@ -129,7 +124,6 @@ func (d *environmentDataSource) Read(ctx context.Context, req datasource.ReadReq
 		data.Description = types.StringValue(env.Description)
 	}
 
-	data.IncludeScaling = types.BoolValue(env.IncludeScaling)
 	data.LastModifiedAt = types.Float64Value(env.LastModifiedAt)
 
 	// Handle nullable LastReportedAt

--- a/internal/provider/data_source_environment_acc_test.go
+++ b/internal/provider/data_source_environment_acc_test.go
@@ -26,7 +26,6 @@ func TestAccEnvironmentDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "type", resourceName, "type"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "include_scaling", resourceName, "include_scaling"),
 					// Verify timestamp fields are populated
 					resource.TestCheckResourceAttrSet(dataSourceName, "last_modified_at"),
 				),
@@ -53,13 +52,11 @@ func TestAccEnvironmentDataSource_computedAttributes(t *testing.T) {
 					resource.TestCheckResourceAttr(dataSourceName, "name", rName),
 					resource.TestCheckResourceAttr(dataSourceName, "type", "ECS"),
 					resource.TestCheckResourceAttr(dataSourceName, "description", description),
-					resource.TestCheckResourceAttr(dataSourceName, "include_scaling", "true"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "last_modified_at"),
 					// Verify data source matches resource
 					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "type", resourceName, "type"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "include_scaling", resourceName, "include_scaling"),
 				),
 			},
 		},
@@ -177,10 +174,9 @@ data "kosli_environment" "test" {
 func testAccEnvironmentDataSourceConfigFull(name, description string) string {
 	return fmt.Sprintf(`
 resource "kosli_environment" "test" {
-  name            = %[1]q
-  type            = "ECS"
-  description     = %[2]q
-  include_scaling = true
+  name        = %[1]q
+  type        = "ECS"
+  description = %[2]q
 }
 
 data "kosli_environment" "test" {

--- a/internal/provider/data_source_environment_test.go
+++ b/internal/provider/data_source_environment_test.go
@@ -40,7 +40,7 @@ func TestEnvironmentDataSource_Schema(t *testing.T) {
 
 	// Verify required attributes exist
 	attrs := resp.Schema.Attributes
-	requiredAttrs := []string{"name", "type", "description", "include_scaling", "last_modified_at", "last_reported_at", "tags"}
+	requiredAttrs := []string{"name", "type", "description", "last_modified_at", "last_reported_at", "tags"}
 	for _, attr := range requiredAttrs {
 		if _, exists := attrs[attr]; !exists {
 			t.Errorf("Expected attribute %q to exist in schema", attr)
@@ -65,10 +65,9 @@ func TestEnvironmentDataSource_Schema(t *testing.T) {
 		t.Error("Expected 'description' attribute to be computed")
 	}
 
-	// Verify include_scaling is computed
-	includeScalingAttr := attrs["include_scaling"]
-	if includeScalingAttr.IsComputed() == false {
-		t.Error("Expected 'include_scaling' attribute to be computed")
+	// include_scaling was removed from the API and must not be in the schema (issue #235)
+	if _, exists := attrs["include_scaling"]; exists {
+		t.Error("Expected 'include_scaling' attribute to be removed from schema")
 	}
 
 	// Verify last_modified_at is computed
@@ -136,7 +135,6 @@ func TestEnvironmentDataSourceModel_Structure(t *testing.T) {
 		Name:           types.StringValue("production-k8s"),
 		Type:           types.StringValue("K8S"),
 		Description:    types.StringValue("Production cluster"),
-		IncludeScaling: types.BoolValue(true),
 		LastModifiedAt: types.Float64Value(1640000000.123456),
 		LastReportedAt: types.Float64Value(1640000100.654321),
 		Tags:           types.MapNull(types.StringType),
@@ -152,10 +150,6 @@ func TestEnvironmentDataSourceModel_Structure(t *testing.T) {
 
 	if model.Description.ValueString() != "Production cluster" {
 		t.Error("Expected Description to be set correctly")
-	}
-
-	if model.IncludeScaling.ValueBool() != true {
-		t.Error("Expected IncludeScaling to be true")
 	}
 
 	if model.LastModifiedAt.ValueFloat64() != 1640000000.123456 {
@@ -185,7 +179,6 @@ func TestEnvironmentDataSourceModel_WithTags(t *testing.T) {
 		Name:           types.StringValue("production-k8s"),
 		Type:           types.StringValue("K8S"),
 		Description:    types.StringNull(),
-		IncludeScaling: types.BoolValue(false),
 		LastModifiedAt: types.Float64Value(1640000000.0),
 		LastReportedAt: types.Float64Null(),
 		Tags:           tagsMap,
@@ -215,7 +208,6 @@ func TestEnvironmentDataSourceModel_WithNullValues(t *testing.T) {
 		Name:           types.StringValue("test-env"),
 		Type:           types.StringValue("docker"),
 		Description:    types.StringNull(),
-		IncludeScaling: types.BoolValue(false),
 		LastModifiedAt: types.Float64Value(1640000000.0),
 		LastReportedAt: types.Float64Null(),
 		Tags:           types.MapNull(types.StringType),
@@ -231,10 +223,6 @@ func TestEnvironmentDataSourceModel_WithNullValues(t *testing.T) {
 
 	if !model.LastReportedAt.IsNull() {
 		t.Error("Expected LastReportedAt to be null")
-	}
-
-	if model.IncludeScaling.ValueBool() != false {
-		t.Error("Expected IncludeScaling to be false")
 	}
 
 	if !model.Tags.IsNull() {

--- a/internal/provider/resource_environment.go
+++ b/internal/provider/resource_environment.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -31,11 +30,10 @@ type environmentResource struct {
 
 // environmentResourceModel describes the resource data model.
 type environmentResourceModel struct {
-	Name           types.String `tfsdk:"name"`
-	Type           types.String `tfsdk:"type"`
-	Description    types.String `tfsdk:"description"`
-	IncludeScaling types.Bool   `tfsdk:"include_scaling"`
-	Tags           types.Map    `tfsdk:"tags"`
+	Name        types.String `tfsdk:"name"`
+	Type        types.String `tfsdk:"type"`
+	Description types.String `tfsdk:"description"`
+	Tags        types.Map    `tfsdk:"tags"`
 }
 
 // Metadata returns the resource type name.
@@ -68,12 +66,6 @@ func (r *environmentResource) Schema(ctx context.Context, req resource.SchemaReq
 			"description": schema.StringAttribute{
 				MarkdownDescription: "Description of the environment. Explains the purpose and characteristics of this deployment target.",
 				Optional:            true,
-			},
-			"include_scaling": schema.BoolAttribute{
-				MarkdownDescription: "Whether to include scaling information when reporting environment snapshots. Defaults to `false`.",
-				Optional:            true,
-				Computed:            true,
-				Default:             booldefault.StaticBool(false),
 			},
 			"tags": schema.MapAttribute{
 				MarkdownDescription: "Key-value pairs to tag the environment.",
@@ -115,10 +107,9 @@ func (r *environmentResource) Create(ctx context.Context, req resource.CreateReq
 
 	// Create API request
 	createReq := &client.CreateEnvironmentRequest{
-		Name:           data.Name.ValueString(),
-		Type:           data.Type.ValueString(),
-		Description:    data.Description.ValueString(),
-		IncludeScaling: data.IncludeScaling.ValueBool(),
+		Name:        data.Name.ValueString(),
+		Type:        data.Type.ValueString(),
+		Description: data.Description.ValueString(),
 	}
 
 	// Call API to create the environment
@@ -219,10 +210,8 @@ func (r *environmentResource) Update(ctx context.Context, req resource.UpdateReq
 	}
 
 	description := data.Description.ValueString()
-	includeScaling := data.IncludeScaling.ValueBool()
 	updateReq := &client.UpdateEnvironmentRequest{
-		Description:    &description,
-		IncludeScaling: &includeScaling,
+		Description: &description,
 	}
 
 	// Call API to update the environment
@@ -300,7 +289,6 @@ func mapEnvToState(ctx context.Context, env *client.Environment, data *environme
 	} else {
 		data.Description = types.StringValue(env.Description)
 	}
-	data.IncludeScaling = types.BoolValue(env.IncludeScaling)
 
 	// Normalize nil tags to empty map to prevent drift when tags = {} is set in config.
 	tags := env.Tags

--- a/internal/provider/resource_environment_acc_test.go
+++ b/internal/provider/resource_environment_acc_test.go
@@ -23,7 +23,6 @@ func TestAccEnvironmentResource_basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "type", "K8S"),
-					resource.TestCheckResourceAttr(resourceName, "include_scaling", "false"),
 				),
 			},
 		},
@@ -46,7 +45,6 @@ func TestAccEnvironmentResource_full(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "type", "ECS"),
 					resource.TestCheckResourceAttr(resourceName, "description", description),
-					resource.TestCheckResourceAttr(resourceName, "include_scaling", "true"),
 				),
 			},
 		},
@@ -70,16 +68,14 @@ func TestAccEnvironmentResource_update(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "description", description1),
-					resource.TestCheckResourceAttr(resourceName, "include_scaling", "true"),
 				),
 			},
-			// Step 2: Update description and include_scaling
+			// Step 2: Update description
 			{
 				Config: testAccEnvironmentResourceConfigUpdate(rName, description2),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "description", description2),
-					resource.TestCheckResourceAttr(resourceName, "include_scaling", "false"),
 				),
 			},
 		},
@@ -246,10 +242,9 @@ resource "kosli_environment" "test" {
 func testAccEnvironmentResourceConfigFull(name, description string) string {
 	return fmt.Sprintf(`
 resource "kosli_environment" "test" {
-  name            = %[1]q
-  type            = "ECS"
-  description     = %[2]q
-  include_scaling = true
+  name        = %[1]q
+  type        = "ECS"
+  description = %[2]q
 }
 `, name, description)
 }
@@ -259,9 +254,8 @@ resource "kosli_environment" "test" {
 func testAccEnvironmentResourceConfigNoDescription(name string) string {
 	return fmt.Sprintf(`
 resource "kosli_environment" "test" {
-  name            = %[1]q
-  type            = "ECS"
-  include_scaling = true
+  name = %[1]q
+  type = "ECS"
 }
 `, name)
 }
@@ -270,10 +264,9 @@ resource "kosli_environment" "test" {
 func testAccEnvironmentResourceConfigUpdate(name, description string) string {
 	return fmt.Sprintf(`
 resource "kosli_environment" "test" {
-  name            = %[1]q
-  type            = "ECS"
-  description     = %[2]q
-  include_scaling = false
+  name        = %[1]q
+  type        = "ECS"
+  description = %[2]q
 }
 `, name, description)
 }

--- a/internal/provider/resource_environment_test.go
+++ b/internal/provider/resource_environment_test.go
@@ -40,7 +40,7 @@ func TestEnvironmentResource_Schema(t *testing.T) {
 
 	// Verify required attributes exist
 	attrs := resp.Schema.Attributes
-	requiredAttrs := []string{"name", "type", "description", "include_scaling", "tags"}
+	requiredAttrs := []string{"name", "type", "description", "tags"}
 	for _, attr := range requiredAttrs {
 		if _, exists := attrs[attr]; !exists {
 			t.Errorf("Expected attribute %q to exist in schema", attr)
@@ -65,13 +65,9 @@ func TestEnvironmentResource_Schema(t *testing.T) {
 		t.Error("Expected 'description' attribute to be optional")
 	}
 
-	// Verify include_scaling is optional and computed
-	includeScalingAttr := attrs["include_scaling"]
-	if includeScalingAttr.IsOptional() == false {
-		t.Error("Expected 'include_scaling' attribute to be optional")
-	}
-	if includeScalingAttr.IsComputed() == false {
-		t.Error("Expected 'include_scaling' attribute to be computed")
+	// include_scaling was removed from the API and must not be in the schema (issue #235)
+	if _, exists := attrs["include_scaling"]; exists {
+		t.Error("Expected 'include_scaling' attribute to be removed from schema")
 	}
 
 	// Verify tags is optional
@@ -124,11 +120,10 @@ func TestEnvironmentResource_Configure_WrongType(t *testing.T) {
 func TestEnvironmentResourceModel_Structure(t *testing.T) {
 	// Test that the model can be created with expected fields
 	model := environmentResourceModel{
-		Name:           types.StringValue("production-k8s"),
-		Type:           types.StringValue("K8S"),
-		Description:    types.StringValue("Production cluster"),
-		IncludeScaling: types.BoolValue(true),
-		Tags:           types.MapNull(types.StringType),
+		Name:        types.StringValue("production-k8s"),
+		Type:        types.StringValue("K8S"),
+		Description: types.StringValue("Production cluster"),
+		Tags:        types.MapNull(types.StringType),
 	}
 
 	if model.Name.ValueString() != "production-k8s" {
@@ -141,10 +136,6 @@ func TestEnvironmentResourceModel_Structure(t *testing.T) {
 
 	if model.Description.ValueString() != "Production cluster" {
 		t.Error("Expected Description to be set correctly")
-	}
-
-	if model.IncludeScaling.ValueBool() != true {
-		t.Error("Expected IncludeScaling to be set correctly")
 	}
 
 	if !model.Tags.IsNull() {
@@ -163,11 +154,10 @@ func TestEnvironmentResourceModel_WithTags(t *testing.T) {
 	}
 
 	model := environmentResourceModel{
-		Name:           types.StringValue("production-k8s"),
-		Type:           types.StringValue("K8S"),
-		Description:    types.StringNull(),
-		IncludeScaling: types.BoolValue(false),
-		Tags:           tagsMap,
+		Name:        types.StringValue("production-k8s"),
+		Type:        types.StringValue("K8S"),
+		Description: types.StringNull(),
+		Tags:        tagsMap,
 	}
 
 	if model.Tags.IsNull() {
@@ -191,11 +181,10 @@ func TestEnvironmentResourceModel_WithTags(t *testing.T) {
 func TestEnvironmentResourceModel_WithNullValues(t *testing.T) {
 	// Test that the model handles null values correctly
 	model := environmentResourceModel{
-		Name:           types.StringValue("test-env"),
-		Type:           types.StringValue("docker"),
-		Description:    types.StringNull(),
-		IncludeScaling: types.BoolValue(false),
-		Tags:           types.MapNull(types.StringType),
+		Name:        types.StringValue("test-env"),
+		Type:        types.StringValue("docker"),
+		Description: types.StringNull(),
+		Tags:        types.MapNull(types.StringType),
 	}
 
 	if model.Name.ValueString() != "test-env" {
@@ -204,10 +193,6 @@ func TestEnvironmentResourceModel_WithNullValues(t *testing.T) {
 
 	if !model.Description.IsNull() {
 		t.Error("Expected Description to be null")
-	}
-
-	if model.IncludeScaling.ValueBool() != false {
-		t.Error("Expected IncludeScaling to be false")
 	}
 
 	if !model.Tags.IsNull() {

--- a/pkg/client/environments.go
+++ b/pkg/client/environments.go
@@ -7,17 +7,15 @@ import (
 
 // Environment represents a Kosli environment as returned by the API
 type Environment struct {
-	Org               string            `json:"org"`
-	Name              string            `json:"name"`
-	Type              string            `json:"type"`
-	Description       string            `json:"description"`
-	LastModifiedAt    float64           `json:"last_modified_at"`
-	LastReportedAt    *float64          `json:"last_reported_at"` // nullable
-	State             any               `json:"state"`            // any JSON type
-	IncludeScaling    bool              `json:"include_scaling"`
-	RequireProvenance bool              `json:"require_provenance"`
-	Tags              map[string]string `json:"tags"`
-	Policies          []any             `json:"policies"`
+	Org            string            `json:"org"`
+	Name           string            `json:"name"`
+	Type           string            `json:"type"`
+	Description    string            `json:"description"`
+	LastModifiedAt float64           `json:"last_modified_at"`
+	LastReportedAt *float64          `json:"last_reported_at"` // nullable
+	State          any               `json:"state"`            // any JSON type
+	Tags           map[string]string `json:"tags"`
+	Policies       []any             `json:"policies"`
 	// Logical environments only:
 	IncludedEnvironments []string `json:"included_environments,omitempty"`
 }
@@ -27,7 +25,6 @@ type CreateEnvironmentRequest struct {
 	Name                 string
 	Type                 string
 	Description          string
-	IncludeScaling       bool
 	IncludedEnvironments []string // for logical environments only
 	Policies             []any    // policies to attach to the environment
 }
@@ -43,7 +40,6 @@ type CreateEnvironmentRequest struct {
 // (see issue #122).
 type UpdateEnvironmentRequest struct {
 	Description          *string  // nil to omit; pointer to "" to clear
-	IncludeScaling       *bool    // nil to omit (e.g. logical environments)
 	IncludedEnvironments []string // for logical environments only; nil to omit
 }
 
@@ -99,7 +95,6 @@ func (c *Client) CreateEnvironment(ctx context.Context, req *CreateEnvironmentRe
 		"name":                  req.Name,
 		"type":                  req.Type,
 		"description":           req.Description,
-		"include_scaling":       req.IncludeScaling,
 		"included_environments": req.IncludedEnvironments,
 		"policies":              req.Policies,
 	}
@@ -126,13 +121,10 @@ func (c *Client) UpdateEnvironment(ctx context.Context, name string, req *Update
 
 	// Build request body. Only include optional fields when the caller
 	// provided them, so fields that don't apply to a given environment
-	// kind (e.g. include_scaling on a logical environment) are omitted.
+	// kind (e.g. included_environments on a physical environment) are omitted.
 	body := map[string]any{}
 	if req.Description != nil {
 		body["description"] = *req.Description
-	}
-	if req.IncludeScaling != nil {
-		body["include_scaling"] = *req.IncludeScaling
 	}
 	if req.IncludedEnvironments != nil {
 		body["included_environments"] = req.IncludedEnvironments

--- a/pkg/client/environments_test.go
+++ b/pkg/client/environments_test.go
@@ -23,30 +23,26 @@ func TestListEnvironments_Success(t *testing.T) {
 		// Return mock response
 		resp := []Environment{
 			{
-				Org:               "test-org",
-				Name:              "production-k8s",
-				Type:              "K8S",
-				Description:       "Production Kubernetes cluster",
-				LastModifiedAt:    1234567890.123456,
-				LastReportedAt:    nil,
-				State:             nil,
-				IncludeScaling:    true,
-				RequireProvenance: false,
-				Tags:              map[string]string{"env": "prod"},
-				Policies:          []any{},
+				Org:            "test-org",
+				Name:           "production-k8s",
+				Type:           "K8S",
+				Description:    "Production Kubernetes cluster",
+				LastModifiedAt: 1234567890.123456,
+				LastReportedAt: nil,
+				State:          nil,
+				Tags:           map[string]string{"env": "prod"},
+				Policies:       []any{},
 			},
 			{
-				Org:               "test-org",
-				Name:              "staging-ecs",
-				Type:              "ECS",
-				Description:       "Staging ECS cluster",
-				LastModifiedAt:    1234567891.123456,
-				LastReportedAt:    floatPtr(1234567892.123456),
-				State:             map[string]any{"status": "healthy"},
-				IncludeScaling:    false,
-				RequireProvenance: true,
-				Tags:              map[string]string{},
-				Policies:          []any{},
+				Org:            "test-org",
+				Name:           "staging-ecs",
+				Type:           "ECS",
+				Description:    "Staging ECS cluster",
+				LastModifiedAt: 1234567891.123456,
+				LastReportedAt: floatPtr(1234567892.123456),
+				State:          map[string]any{"status": "healthy"},
+				Tags:           map[string]string{},
+				Policies:       []any{},
 			},
 		}
 
@@ -82,18 +78,12 @@ func TestListEnvironments_Success(t *testing.T) {
 	if environments[0].LastReportedAt != nil {
 		t.Errorf("expected nil LastReportedAt, got %v", environments[0].LastReportedAt)
 	}
-	if !environments[0].IncludeScaling {
-		t.Error("expected IncludeScaling to be true")
-	}
 
 	// Verify second environment with nullable fields
 	if environments[1].LastReportedAt == nil {
 		t.Error("expected non-nil LastReportedAt")
 	} else if *environments[1].LastReportedAt != 1234567892.123456 {
 		t.Errorf("expected LastReportedAt 1234567892.123456, got %f", *environments[1].LastReportedAt)
-	}
-	if environments[1].RequireProvenance != true {
-		t.Error("expected RequireProvenance to be true")
 	}
 }
 
@@ -110,17 +100,15 @@ func TestGetEnvironment_Success(t *testing.T) {
 
 		// Return mock response
 		resp := Environment{
-			Org:               "test-org",
-			Name:              "production-k8s",
-			Type:              "K8S",
-			Description:       "Production Kubernetes cluster",
-			LastModifiedAt:    1234567890.123456,
-			LastReportedAt:    floatPtr(1234567891.123456),
-			State:             map[string]any{"ready": true},
-			IncludeScaling:    true,
-			RequireProvenance: false,
-			Tags:              map[string]string{"env": "prod"},
-			Policies:          []any{},
+			Org:            "test-org",
+			Name:           "production-k8s",
+			Type:           "K8S",
+			Description:    "Production Kubernetes cluster",
+			LastModifiedAt: 1234567890.123456,
+			LastReportedAt: floatPtr(1234567891.123456),
+			State:          map[string]any{"ready": true},
+			Tags:           map[string]string{"env": "prod"},
+			Policies:       []any{},
 		}
 
 		w.Header().Set("Content-Type", "application/json")
@@ -152,12 +140,6 @@ func TestGetEnvironment_Success(t *testing.T) {
 	}
 	if env.LastReportedAt == nil {
 		t.Error("expected non-nil LastReportedAt")
-	}
-	if !env.IncludeScaling {
-		t.Error("expected IncludeScaling to be true")
-	}
-	if env.RequireProvenance {
-		t.Error("expected RequireProvenance to be false")
 	}
 }
 
@@ -221,8 +203,9 @@ func TestCreateEnvironment_Success(t *testing.T) {
 		if body["description"] != "Production cluster" {
 			t.Errorf("expected description 'Production cluster', got %v", body["description"])
 		}
-		if body["include_scaling"] != true {
-			t.Errorf("expected include_scaling true, got %v", body["include_scaling"])
+		// include_scaling was removed from the API and must never be sent (issue #235)
+		if _, exists := body["include_scaling"]; exists {
+			t.Errorf("expected include_scaling to be omitted, got %v", body["include_scaling"])
 		}
 
 		// Verify policies field is sent correctly
@@ -249,11 +232,10 @@ func TestCreateEnvironment_Success(t *testing.T) {
 	}
 
 	req := &CreateEnvironmentRequest{
-		Name:           "production-k8s",
-		Type:           "K8S",
-		Description:    "Production cluster",
-		IncludeScaling: true,
-		Policies:       []any{}, // Resource layer will send empty array initially
+		Name:        "production-k8s",
+		Type:        "K8S",
+		Description: "Production cluster",
+		Policies:    []any{}, // Resource layer will send empty array initially
 	}
 
 	err = client.CreateEnvironment(context.Background(), req)
@@ -295,11 +277,10 @@ func TestCreateEnvironment_Idempotent(t *testing.T) {
 	}
 
 	req := &CreateEnvironmentRequest{
-		Name:           "production-k8s",
-		Type:           "K8S",
-		Description:    "Production cluster",
-		IncludeScaling: false,
-		Policies:       []any{},
+		Name:        "production-k8s",
+		Type:        "K8S",
+		Description: "Production cluster",
+		Policies:    []any{},
 	}
 
 	// First call (create)
@@ -436,12 +417,12 @@ func TestEnvironment_NullableFields(t *testing.T) {
 	}{
 		{
 			name:     "null LastReportedAt",
-			respJSON: `{"org":"test-org","name":"env1","type":"K8S","description":"","last_modified_at":123.456,"last_reported_at":null,"state":null,"include_scaling":false,"require_provenance":false,"tags":{},"policies":[]}`,
+			respJSON: `{"org":"test-org","name":"env1","type":"K8S","description":"","last_modified_at":123.456,"last_reported_at":null,"state":null,"tags":{},"policies":[]}`,
 			wantNil:  true,
 		},
 		{
 			name:     "non-null LastReportedAt",
-			respJSON: `{"org":"test-org","name":"env2","type":"ECS","description":"","last_modified_at":123.456,"last_reported_at":789.012,"state":{},"include_scaling":false,"require_provenance":false,"tags":{},"policies":[]}`,
+			respJSON: `{"org":"test-org","name":"env2","type":"ECS","description":"","last_modified_at":123.456,"last_reported_at":789.012,"state":{},"tags":{},"policies":[]}`,
 			wantNil:  false,
 		},
 	}
@@ -500,8 +481,6 @@ func TestGetEnvironment_LogicalEnvironment(t *testing.T) {
 			LastModifiedAt:       1234567890.123456,
 			LastReportedAt:       nil,
 			State:                nil,
-			IncludeScaling:       false,
-			RequireProvenance:    false,
 			Tags:                 map[string]string{},
 			Policies:             []any{},
 			IncludedEnvironments: []string{"prod-k8s", "prod-ecs", "prod-lambda"},
@@ -544,11 +523,6 @@ func TestGetEnvironment_LogicalEnvironment(t *testing.T) {
 		if env.IncludedEnvironments[i] != expectedEnv {
 			t.Errorf("expected included_environments[%d] = %s, got %s", i, expectedEnv, env.IncludedEnvironments[i])
 		}
-	}
-
-	// Verify logical environments don't have include_scaling set to true
-	if env.IncludeScaling {
-		t.Error("expected IncludeScaling to be false for logical environment")
 	}
 }
 
@@ -630,9 +604,9 @@ func TestUpdateEnvironment_LogicalChangedEnvironments(t *testing.T) {
 				t.Errorf("call 2: expected 3 environments, got %d", len(includedEnvs))
 			}
 		}
-		// include_scaling must be omitted for logical environments
+		// include_scaling was removed from the API and must never be sent (issue #235)
 		if _, exists := body["include_scaling"]; exists {
-			t.Errorf("call %d: expected include_scaling to be omitted for logical environment, got %v", callCount, body["include_scaling"])
+			t.Errorf("call %d: expected include_scaling to be omitted, got %v", callCount, body["include_scaling"])
 		}
 
 		w.WriteHeader(http.StatusOK)
@@ -675,17 +649,15 @@ func TestListEnvironments_WithLogical(t *testing.T) {
 		// Return mix of physical and logical environments
 		resp := []Environment{
 			{
-				Org:               "test-org",
-				Name:              "production-k8s",
-				Type:              "K8S",
-				Description:       "Production cluster",
-				LastModifiedAt:    1234567890.123456,
-				LastReportedAt:    nil,
-				State:             nil,
-				IncludeScaling:    true,
-				RequireProvenance: false,
-				Tags:              map[string]string{},
-				Policies:          []any{},
+				Org:            "test-org",
+				Name:           "production-k8s",
+				Type:           "K8S",
+				Description:    "Production cluster",
+				LastModifiedAt: 1234567890.123456,
+				LastReportedAt: nil,
+				State:          nil,
+				Tags:           map[string]string{},
+				Policies:       []any{},
 			},
 			{
 				Org:                  "test-org",
@@ -695,8 +667,6 @@ func TestListEnvironments_WithLogical(t *testing.T) {
 				LastModifiedAt:       1234567891.123456,
 				LastReportedAt:       nil,
 				State:                nil,
-				IncludeScaling:       false,
-				RequireProvenance:    false,
 				Tags:                 map[string]string{},
 				Policies:             []any{},
 				IncludedEnvironments: []string{"production-k8s"},
@@ -768,8 +738,9 @@ func TestUpdateEnvironment_Success(t *testing.T) {
 		if body["description"] != "Updated description" {
 			t.Errorf("expected description 'Updated description', got %v", body["description"])
 		}
-		if body["include_scaling"] != true {
-			t.Errorf("expected include_scaling true, got %v", body["include_scaling"])
+		// include_scaling was removed from the API and must never be sent (issue #235)
+		if _, exists := body["include_scaling"]; exists {
+			t.Errorf("expected include_scaling to be omitted, got %v", body["include_scaling"])
 		}
 		// included_environments should be omitted for physical env updates
 		if _, exists := body["included_environments"]; exists {
@@ -797,10 +768,8 @@ func TestUpdateEnvironment_Success(t *testing.T) {
 	}
 
 	description := "Updated description"
-	includeScaling := true
 	req := &UpdateEnvironmentRequest{
-		Description:    &description,
-		IncludeScaling: &includeScaling,
+		Description: &description,
 	}
 
 	if err := client.UpdateEnvironment(context.Background(), "production-k8s", req); err != nil {
@@ -839,10 +808,8 @@ func TestUpdateEnvironment_ClearDescription(t *testing.T) {
 	}
 
 	description := ""
-	includeScaling := false
 	req := &UpdateEnvironmentRequest{
-		Description:    &description,
-		IncludeScaling: &includeScaling,
+		Description: &description,
 	}
 
 	if err := client.UpdateEnvironment(context.Background(), "production-k8s", req); err != nil {
@@ -851,7 +818,7 @@ func TestUpdateEnvironment_ClearDescription(t *testing.T) {
 }
 
 // TestUpdateEnvironment_OmitsNilFields verifies that nil pointer fields are
-// omitted from the request body — for example, a scaling-only update should
+// omitted from the request body - for example, a members-only update should
 // not contain a "description" key, leaving the existing description unchanged.
 func TestUpdateEnvironment_OmitsNilFields(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -862,11 +829,8 @@ func TestUpdateEnvironment_OmitsNilFields(t *testing.T) {
 		if _, exists := body["description"]; exists {
 			t.Errorf("expected description to be omitted, got %v", body["description"])
 		}
-		if _, exists := body["included_environments"]; exists {
-			t.Errorf("expected included_environments to be omitted, got %v", body["included_environments"])
-		}
-		if body["include_scaling"] != true {
-			t.Errorf("expected include_scaling true, got %v", body["include_scaling"])
+		if _, exists := body["included_environments"]; !exists {
+			t.Error("expected included_environments in PATCH body")
 		}
 
 		w.WriteHeader(http.StatusOK)
@@ -882,19 +846,17 @@ func TestUpdateEnvironment_OmitsNilFields(t *testing.T) {
 		t.Fatalf("failed to create client: %v", err)
 	}
 
-	includeScaling := true
 	req := &UpdateEnvironmentRequest{
-		IncludeScaling: &includeScaling,
+		IncludedEnvironments: []string{"env1"},
 	}
 
-	if err := client.UpdateEnvironment(context.Background(), "production-k8s", req); err != nil {
+	if err := client.UpdateEnvironment(context.Background(), "logical-prod", req); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 }
 
 // TestUpdateEnvironment_LogicalIncludesEnvironments verifies that
-// included_environments is sent for logical environment updates and that
-// include_scaling is omitted (logical envs don't have scaling).
+// included_environments is sent for logical environment updates.
 func TestUpdateEnvironment_LogicalIncludesEnvironments(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPatch {
@@ -917,10 +879,9 @@ func TestUpdateEnvironment_LogicalIncludesEnvironments(t *testing.T) {
 		if len(included) != 2 || included[0] != "env1" || included[1] != "env2" {
 			t.Errorf("unexpected included_environments: %v", included)
 		}
-		// include_scaling does not apply to logical environments and must
-		// not be sent in the PATCH body.
+		// include_scaling was removed from the API and must never be sent (issue #235)
 		if _, exists := body["include_scaling"]; exists {
-			t.Errorf("expected include_scaling to be omitted for logical environment, got %v", body["include_scaling"])
+			t.Errorf("expected include_scaling to be omitted, got %v", body["include_scaling"])
 		}
 
 		w.WriteHeader(http.StatusOK)

--- a/templates/resources/environment.md.tmpl
+++ b/templates/resources/environment.md.tmpl
@@ -39,12 +39,6 @@ The `type` attribute must be one of the following physical environment types:
 - `server` - Bare-metal or VM servers
 - `lambda` - AWS Lambda functions
 
-## Configuration Options
-
-### Include Scaling
-
-The `include_scaling` attribute (default: `false`) determines whether scaling events in the environment should be tracked. This is useful for environments with auto-scaling where you want to monitor scale-up and scale-down events.
-
 ## Import
 
 Environments can be imported using their name:


### PR DESCRIPTION
Closes #235.

## Problem

The Kosli API no longer honors `include_scaling` on `/api/v2/environments/{org}`. `PUT`/`PATCH` return 200 but silently drop the field, and `GET` always reports it as `false` regardless of what was requested. Any apply that set `include_scaling = true` failed:

```
Error: Provider produced inconsistent result after apply

When applying changes to kosli_environment.test, provider
"provider[\"registry.terraform.io/hashicorp/kosli\"]" produced an unexpected
new value: .include_scaling: was cty.True, but now cty.False.
```

This broke `TestAccEnvironmentResource_full`, `_update`, `_clearDescription`, and `TestAccEnvironmentDataSource_computedAttributes` - all four only in the steps that set the attribute to `true`.

## Change

`include_scaling` is removed outright rather than deprecated, since the API gives the provider no way to honor it:

- **`pkg/client`** - dropped `Environment.IncludeScaling`, the field on `CreateEnvironmentRequest` and `UpdateEnvironmentRequest`, and the `include_scaling` key from the PUT and PATCH bodies.
- **`kosli_environment` resource and data source** - dropped the schema attribute, model field, and state mapping.
- **Tests** - fixtures and assertions updated. Where a test previously asserted the field *was* sent, it now asserts it is absent, and both schema tests assert the attribute is gone, so a re-add is caught.
- **Examples, template, docs** - references removed and `docs/` regenerated.

Also drops `Environment.RequireProvenance`, which the API has stopped returning entirely (the key is gone, unlike `include_scaling`). It was only ever in the client struct and never exposed in a schema, so nothing user-facing changes.

## Upgrade impact

This is a breaking change for anyone setting `include_scaling`. The only required action is deleting the attribute from their configuration.

No schema version bump or state upgrader is needed. Verified by applying a `kosli_environment` with v0.9.1 (so `include_scaling` lands in state), then swapping in this build:

| State has `include_scaling` | Config | Result |
|---|---|---|
| yes | still sets it | `Error: Unsupported argument ... is not expected here`, pointing at the line |
| yes | attribute removed | `No changes. Your infrastructure matches the configuration.` Next apply drops the key from state |

## Verification

- `go test ./...` - pass
- `make vet`, `make lint` - 0 issues; `gofmt` clean
- `make testacc-environment`, `make testacc-environment-datasource`, `make testacc-logical-environment`, `make testacc-logical-environment-datasource` - all pass (the four previously-failing tests now pass)
- `terraform validate` on both changed examples - pass
- `make docs` run and generated files committed
