### PR TITLE
feat(custom_attestation_type): add summary attribute for attestation detail rows

### DIFF
--- a/docs/data-sources/custom_attestation_type.md
+++ b/docs/data-sources/custom_attestation_type.md
@@ -37,8 +37,8 @@ resource "kosli_custom_attestation_type" "security_strict" {
   description = "Stricter security requirements"
 
   # Reuse the schema and summary rows from the existing type
-  schema       = data.kosli_custom_attestation_type.security.schema
-  summary_json = data.kosli_custom_attestation_type.security.summary_json
+  schema  = data.kosli_custom_attestation_type.security.schema
+  summary = data.kosli_custom_attestation_type.security.summary
 
   # Apply stricter validation rules
   jq_rules = [
@@ -61,7 +61,7 @@ output "security_scan_rules" {
 
 output "security_scan_summary" {
   description = "Summary rows shown on the attestation detail page, as a JSON array"
-  value       = data.kosli_custom_attestation_type.security.summary_json
+  value       = data.kosli_custom_attestation_type.security.summary
 }
 
 output "security_scan_archived" {
@@ -89,4 +89,4 @@ The `archived` attribute indicates whether an attestation type has been deleted/
 - `description` (String) A description of what this attestation type validates.
 - `jq_rules` (List of String) List of jq expressions that define evaluation rules. All rules must evaluate to `true` for compliance.
 - `schema` (String) JSON Schema that defines the structure of attestation data.
-- `summary_json` (String) JSON array of ordered, labelled jq expressions rendered as rows on the attestation detail page in Kosli. Each element is an object with a `name` and an `expression`. Null when the type defines no summary.
+- `summary` (String) JSON array of ordered, labelled jq expressions rendered as rows on the attestation detail page in Kosli. Each element is an object with a `name` and an `expression`. Null when the type defines no summary.

--- a/docs/data-sources/custom_attestation_type.md
+++ b/docs/data-sources/custom_attestation_type.md
@@ -36,8 +36,9 @@ resource "kosli_custom_attestation_type" "security_strict" {
   name        = "security-scan-strict"
   description = "Stricter security requirements"
 
-  # Reuse the schema from the existing type
-  schema = data.kosli_custom_attestation_type.security.schema
+  # Reuse the schema and summary rows from the existing type
+  schema       = data.kosli_custom_attestation_type.security.schema
+  summary_json = data.kosli_custom_attestation_type.security.summary_json
 
   # Apply stricter validation rules
   jq_rules = [
@@ -56,6 +57,11 @@ output "security_scan_description" {
 output "security_scan_rules" {
   description = "JQ rules for the security scan attestation type"
   value       = data.kosli_custom_attestation_type.security.jq_rules
+}
+
+output "security_scan_summary" {
+  description = "Summary rows shown on the attestation detail page, as a JSON array"
+  value       = data.kosli_custom_attestation_type.security.summary_json
 }
 
 output "security_scan_archived" {
@@ -83,3 +89,4 @@ The `archived` attribute indicates whether an attestation type has been deleted/
 - `description` (String) A description of what this attestation type validates.
 - `jq_rules` (List of String) List of jq expressions that define evaluation rules. All rules must evaluate to `true` for compliance.
 - `schema` (String) JSON Schema that defines the structure of attestation data.
+- `summary_json` (String) JSON array of ordered, labelled jq expressions rendered as rows on the attestation detail page in Kosli. Each element is an object with a `name` and an `expression`. Null when the type defines no summary.

--- a/docs/resources/custom_attestation_type.md
+++ b/docs/resources/custom_attestation_type.md
@@ -40,6 +40,7 @@ resource "kosli_custom_attestation_type" "security_scan" {
       medium_vulnerabilities   = { type = "integer" }
       scan_date                = { type = "string" }
       scanner_version          = { type = "string" }
+      report_url               = { type = "string" }
     }
     required = ["critical_vulnerabilities", "high_vulnerabilities", "scan_date"]
   })
@@ -48,6 +49,15 @@ resource "kosli_custom_attestation_type" "security_scan" {
     ".critical_vulnerabilities == 0",
     ".high_vulnerabilities < 5"
   ]
+
+  # Ordered, labelled values shown on the attestation detail page in Kosli.
+  # A value that is a valid URL renders as a clickable link.
+  summary_json = jsonencode([
+    { name = "Critical", expression = ".critical_vulnerabilities" },
+    { name = "High", expression = ".high_vulnerabilities" },
+    { name = "Scanner", expression = ".scanner_version" },
+    { name = "Report", expression = ".report_url" },
+  ])
 }
 
 # Code coverage attestation type
@@ -80,6 +90,21 @@ resource "kosli_custom_attestation_type" "code_coverage" {
   ]
 }
 
+# Attestation type whose schema and summary are kept in standalone JSON files,
+# so the same definitions can be shared with the Kosli CLI
+resource "kosli_custom_attestation_type" "code_quality" {
+  name        = "code-quality"
+  description = "Validates code quality metrics"
+
+  schema       = file("${path.module}/schemas/code-quality.json")
+  summary_json = file("${path.module}/summaries/code-quality.json")
+
+  jq_rules = [
+    ".line_coverage >= 80",
+    ".lint_errors == 0"
+  ]
+}
+
 # Age verification attestation type with only jq rules (no schema)
 resource "kosli_custom_attestation_type" "age_verification" {
   name        = "age-verification"
@@ -98,7 +123,7 @@ resource "kosli_custom_attestation_type" "schema_validation" {
     properties = {
       timestamp = { type = "string" }
       metadata  = { type = "object" }
-      status    = {
+      status = {
         type = "string"
         enum = ["pass", "fail", "skip"]
       }
@@ -165,3 +190,4 @@ terraform import kosli_custom_attestation_type.security_scan security-scan
 - `description` (String) Description of the custom attestation type. Explains what this attestation type validates.
 - `jq_rules` (List of String) List of jq evaluation rules. Each rule is a jq expression that must evaluate to true for the attestation to be considered compliant. Example: `[".coverage >= 80"]`. If omitted, no evaluation is performed.
 - `schema` (String) JSON Schema definition that defines the structure of attestation data. Can be provided inline using heredoc syntax or loaded from a file using `file()`. If omitted, no schema validation is performed. Semantic equality is used for comparison, so formatting differences are ignored.
+- `summary_json` (String) JSON array of ordered, labelled jq expressions rendered as rows on the attestation detail page in Kosli. Each element is an object with a `name` (the row label) and an `expression` (a jq expression evaluated against the attestation data); values that are valid URLs render as links. Can be provided inline using `jsonencode()`/heredoc syntax or loaded from a file using `file()`, so the same JSON can be shared with the Kosli CLI. Example: `jsonencode([{ name = "Coverage", expression = ".coverage" }])`. If omitted, the attestation detail page falls back to showing the jq evaluation results as a pass/fail checklist; removing it from a type that had one clears the summary. Semantic JSON equality is used when reading the value back from Kosli, so your formatting is preserved rather than being rewritten to the API's compact form.

--- a/docs/resources/custom_attestation_type.md
+++ b/docs/resources/custom_attestation_type.md
@@ -52,7 +52,7 @@ resource "kosli_custom_attestation_type" "security_scan" {
 
   # Ordered, labelled values shown on the attestation detail page in Kosli.
   # A value that is a valid URL renders as a clickable link.
-  summary_json = jsonencode([
+  summary = jsonencode([
     { name = "Critical", expression = ".critical_vulnerabilities" },
     { name = "High", expression = ".high_vulnerabilities" },
     { name = "Scanner", expression = ".scanner_version" },
@@ -96,8 +96,8 @@ resource "kosli_custom_attestation_type" "code_quality" {
   name        = "code-quality"
   description = "Validates code quality metrics"
 
-  schema       = file("${path.module}/schemas/code-quality.json")
-  summary_json = file("${path.module}/summaries/code-quality.json")
+  schema  = file("${path.module}/schemas/code-quality.json")
+  summary = file("${path.module}/summaries/code-quality.json")
 
   jq_rules = [
     ".line_coverage >= 80",
@@ -190,4 +190,4 @@ terraform import kosli_custom_attestation_type.security_scan security-scan
 - `description` (String) Description of the custom attestation type. Explains what this attestation type validates.
 - `jq_rules` (List of String) List of jq evaluation rules. Each rule is a jq expression that must evaluate to true for the attestation to be considered compliant. Example: `[".coverage >= 80"]`. If omitted, no evaluation is performed.
 - `schema` (String) JSON Schema definition that defines the structure of attestation data. Can be provided inline using heredoc syntax or loaded from a file using `file()`. If omitted, no schema validation is performed. Semantic equality is used for comparison, so formatting differences are ignored.
-- `summary_json` (String) JSON array of ordered, labelled jq expressions rendered as rows on the attestation detail page in Kosli. Each element is an object with a `name` (the row label) and an `expression` (a jq expression evaluated against the attestation data); values that are valid URLs render as links. Can be provided inline using `jsonencode()`/heredoc syntax or loaded from a file using `file()`, so the same JSON can be shared with the Kosli CLI. Example: `jsonencode([{ name = "Coverage", expression = ".coverage" }])`. If omitted, the attestation detail page falls back to showing the jq evaluation results as a pass/fail checklist; removing it from a type that had one clears the summary. Semantic JSON equality is used when reading the value back from Kosli, so your formatting is preserved rather than being rewritten to the API's compact form.
+- `summary` (String) JSON array of ordered, labelled jq expressions rendered as rows on the attestation detail page in Kosli. Each element is an object with a `name` (the row label) and an `expression` (a jq expression evaluated against the attestation data); values that are valid URLs render as links. Can be provided inline using `jsonencode()`/heredoc syntax or loaded from a file using `file()`, so the same JSON can be kept in one place and shared with other tooling. Example: `jsonencode([{ name = "Coverage", expression = ".coverage" }])`. If omitted, the attestation detail page falls back to showing the jq evaluation results as a pass/fail checklist; removing it from a type that had one clears the summary. Semantic JSON equality is used when reading the value back from Kosli, so your formatting is preserved rather than being rewritten to the API's compact form.

--- a/examples/data-sources/kosli_custom_attestation_type/data-source.tf
+++ b/examples/data-sources/kosli_custom_attestation_type/data-source.tf
@@ -17,8 +17,8 @@ resource "kosli_custom_attestation_type" "security_strict" {
   description = "Stricter security requirements"
 
   # Reuse the schema and summary rows from the existing type
-  schema       = data.kosli_custom_attestation_type.security.schema
-  summary_json = data.kosli_custom_attestation_type.security.summary_json
+  schema  = data.kosli_custom_attestation_type.security.schema
+  summary = data.kosli_custom_attestation_type.security.summary
 
   # Apply stricter validation rules
   jq_rules = [
@@ -41,7 +41,7 @@ output "security_scan_rules" {
 
 output "security_scan_summary" {
   description = "Summary rows shown on the attestation detail page, as a JSON array"
-  value       = data.kosli_custom_attestation_type.security.summary_json
+  value       = data.kosli_custom_attestation_type.security.summary
 }
 
 output "security_scan_archived" {

--- a/examples/data-sources/kosli_custom_attestation_type/data-source.tf
+++ b/examples/data-sources/kosli_custom_attestation_type/data-source.tf
@@ -16,8 +16,9 @@ resource "kosli_custom_attestation_type" "security_strict" {
   name        = "security-scan-strict"
   description = "Stricter security requirements"
 
-  # Reuse the schema from the existing type
-  schema = data.kosli_custom_attestation_type.security.schema
+  # Reuse the schema and summary rows from the existing type
+  schema       = data.kosli_custom_attestation_type.security.schema
+  summary_json = data.kosli_custom_attestation_type.security.summary_json
 
   # Apply stricter validation rules
   jq_rules = [
@@ -36,6 +37,11 @@ output "security_scan_description" {
 output "security_scan_rules" {
   description = "JQ rules for the security scan attestation type"
   value       = data.kosli_custom_attestation_type.security.jq_rules
+}
+
+output "security_scan_summary" {
+  description = "Summary rows shown on the attestation detail page, as a JSON array"
+  value       = data.kosli_custom_attestation_type.security.summary_json
 }
 
 output "security_scan_archived" {

--- a/examples/resources/kosli_custom_attestation_type/README.md
+++ b/examples/resources/kosli_custom_attestation_type/README.md
@@ -62,12 +62,12 @@ jq_rules = [
 
 ## Summary Rows
 
-The optional `summary_json` attribute is a JSON array of ordered, labelled jq expressions.
+The optional `summary` attribute is a JSON array of ordered, labelled jq expressions.
 Kosli renders them as rows on the attestation detail page, in the order given. A value that
 is a valid URL renders as a clickable link.
 
 ```hcl
-summary_json = jsonencode([
+summary = jsonencode([
   { name = "Critical", expression = ".critical_vulnerabilities" },
   { name = "Report", expression = ".report_url" },
 ])
@@ -77,11 +77,11 @@ Because it is a plain JSON blob, the same definition can be kept in a file and s
 other tooling:
 
 ```hcl
-summary_json = file("${path.module}/summaries/code-quality.json")
+summary = file("${path.module}/summaries/code-quality.json")
 ```
 
-If `summary_json` is omitted, the attestation detail page falls back to showing the jq
-evaluation results as a pass/fail checklist. Removing `summary_json` from a type that had one
+If `summary` is omitted, the attestation detail page falls back to showing the jq
+evaluation results as a pass/fail checklist. Removing `summary` from a type that had one
 clears the summary on the next apply.
 
 ## Terraform Provider Configuration

--- a/examples/resources/kosli_custom_attestation_type/README.md
+++ b/examples/resources/kosli_custom_attestation_type/README.md
@@ -23,6 +23,7 @@ terraform apply
 
 1. **Security Scan**: Attestation type using `jsonencode()` for schema definition
 2. **Code Coverage**: Attestation type using heredoc syntax for better readability
+3. **Code Quality**: Schema and summary loaded from standalone JSON files with `file()`
 
 ## Schema Definition Methods
 
@@ -58,6 +59,30 @@ jq_rules = [
   ".high_vulnerabilities < 5"
 ]
 ```
+
+## Summary Rows
+
+The optional `summary_json` attribute is a JSON array of ordered, labelled jq expressions.
+Kosli renders them as rows on the attestation detail page, in the order given. A value that
+is a valid URL renders as a clickable link.
+
+```hcl
+summary_json = jsonencode([
+  { name = "Critical", expression = ".critical_vulnerabilities" },
+  { name = "Report", expression = ".report_url" },
+])
+```
+
+Because it is a plain JSON blob, the same definition can be kept in a file and shared with
+other tooling:
+
+```hcl
+summary_json = file("${path.module}/summaries/code-quality.json")
+```
+
+If `summary_json` is omitted, the attestation detail page falls back to showing the jq
+evaluation results as a pass/fail checklist. Removing `summary_json` from a type that had one
+clears the summary on the next apply.
 
 ## Terraform Provider Configuration
 

--- a/examples/resources/kosli_custom_attestation_type/resource.tf
+++ b/examples/resources/kosli_custom_attestation_type/resource.tf
@@ -31,7 +31,7 @@ resource "kosli_custom_attestation_type" "security_scan" {
 
   # Ordered, labelled values shown on the attestation detail page in Kosli.
   # A value that is a valid URL renders as a clickable link.
-  summary_json = jsonencode([
+  summary = jsonencode([
     { name = "Critical", expression = ".critical_vulnerabilities" },
     { name = "High", expression = ".high_vulnerabilities" },
     { name = "Scanner", expression = ".scanner_version" },
@@ -75,8 +75,8 @@ resource "kosli_custom_attestation_type" "code_quality" {
   name        = "code-quality"
   description = "Validates code quality metrics"
 
-  schema       = file("${path.module}/schemas/code-quality.json")
-  summary_json = file("${path.module}/summaries/code-quality.json")
+  schema  = file("${path.module}/schemas/code-quality.json")
+  summary = file("${path.module}/summaries/code-quality.json")
 
   jq_rules = [
     ".line_coverage >= 80",

--- a/examples/resources/kosli_custom_attestation_type/resource.tf
+++ b/examples/resources/kosli_custom_attestation_type/resource.tf
@@ -19,6 +19,7 @@ resource "kosli_custom_attestation_type" "security_scan" {
       medium_vulnerabilities   = { type = "integer" }
       scan_date                = { type = "string" }
       scanner_version          = { type = "string" }
+      report_url               = { type = "string" }
     }
     required = ["critical_vulnerabilities", "high_vulnerabilities", "scan_date"]
   })
@@ -27,6 +28,15 @@ resource "kosli_custom_attestation_type" "security_scan" {
     ".critical_vulnerabilities == 0",
     ".high_vulnerabilities < 5"
   ]
+
+  # Ordered, labelled values shown on the attestation detail page in Kosli.
+  # A value that is a valid URL renders as a clickable link.
+  summary_json = jsonencode([
+    { name = "Critical", expression = ".critical_vulnerabilities" },
+    { name = "High", expression = ".high_vulnerabilities" },
+    { name = "Scanner", expression = ".scanner_version" },
+    { name = "Report", expression = ".report_url" },
+  ])
 }
 
 # Code coverage attestation type
@@ -59,6 +69,21 @@ resource "kosli_custom_attestation_type" "code_coverage" {
   ]
 }
 
+# Attestation type whose schema and summary are kept in standalone JSON files,
+# so the same definitions can be shared with the Kosli CLI
+resource "kosli_custom_attestation_type" "code_quality" {
+  name        = "code-quality"
+  description = "Validates code quality metrics"
+
+  schema       = file("${path.module}/schemas/code-quality.json")
+  summary_json = file("${path.module}/summaries/code-quality.json")
+
+  jq_rules = [
+    ".line_coverage >= 80",
+    ".lint_errors == 0"
+  ]
+}
+
 # Age verification attestation type with only jq rules (no schema)
 resource "kosli_custom_attestation_type" "age_verification" {
   name        = "age-verification"
@@ -77,7 +102,7 @@ resource "kosli_custom_attestation_type" "schema_validation" {
     properties = {
       timestamp = { type = "string" }
       metadata  = { type = "object" }
-      status    = {
+      status = {
         type = "string"
         enum = ["pass", "fail", "skip"]
       }

--- a/examples/resources/kosli_custom_attestation_type/schemas/code-quality.json
+++ b/examples/resources/kosli_custom_attestation_type/schemas/code-quality.json
@@ -1,0 +1,9 @@
+{
+  "type": "object",
+  "properties": {
+    "line_coverage": { "type": "number", "minimum": 0, "maximum": 100 },
+    "lint_errors": { "type": "integer" },
+    "report_url": { "type": "string" }
+  },
+  "required": ["line_coverage", "lint_errors"]
+}

--- a/examples/resources/kosli_custom_attestation_type/summaries/code-quality.json
+++ b/examples/resources/kosli_custom_attestation_type/summaries/code-quality.json
@@ -1,0 +1,5 @@
+[
+  { "name": "Line coverage", "expression": ".line_coverage" },
+  { "name": "Lint errors", "expression": ".lint_errors" },
+  { "name": "Report", "expression": ".report_url" }
+]

--- a/internal/provider/data_source_custom_attestation_type.go
+++ b/internal/provider/data_source_custom_attestation_type.go
@@ -30,6 +30,7 @@ type customAttestationTypeDataSourceModel struct {
 	Description types.String         `tfsdk:"description"`
 	Schema      jsontypes.Normalized `tfsdk:"schema"`
 	JqRules     types.List           `tfsdk:"jq_rules"`
+	SummaryJSON jsontypes.Normalized `tfsdk:"summary_json"`
 	Archived    types.Bool           `tfsdk:"archived"`
 }
 
@@ -61,6 +62,11 @@ func (d *customAttestationTypeDataSource) Schema(ctx context.Context, req dataso
 				Computed:            true,
 				ElementType:         types.StringType,
 				MarkdownDescription: "List of jq expressions that define evaluation rules. All rules must evaluate to `true` for compliance.",
+			},
+			"summary_json": schema.StringAttribute{
+				Computed:            true,
+				CustomType:          jsontypes.NormalizedType{},
+				MarkdownDescription: "JSON array of ordered, labelled jq expressions rendered as rows on the attestation detail page in Kosli. Each element is an object with a `name` and an `expression`. Null when the type defines no summary.",
 			},
 			"archived": schema.BoolAttribute{
 				Computed:            true,
@@ -113,8 +119,21 @@ func (d *customAttestationTypeDataSource) Read(ctx context.Context, req datasour
 	// Map response to model
 	data.Name = types.StringValue(attestationType.Name)
 	data.Description = types.StringValue(attestationType.Description)
-	data.Schema = jsontypes.NewNormalizedValue(attestationType.Schema)
 	data.Archived = types.BoolValue(attestationType.Archived)
+
+	// A type with no schema or no summary reports null rather than an empty
+	// string, which the JSON custom type would reject as malformed JSON
+	if attestationType.Schema == "" || attestationType.Schema == "None" {
+		data.Schema = jsontypes.NewNormalizedNull()
+	} else {
+		data.Schema = jsontypes.NewNormalizedValue(attestationType.Schema)
+	}
+
+	if attestationType.Summary == "" {
+		data.SummaryJSON = jsontypes.NewNormalizedNull()
+	} else {
+		data.SummaryJSON = jsontypes.NewNormalizedValue(attestationType.Summary)
+	}
 
 	// Convert jq_rules (API client already transformed from evaluator format)
 	jqRules := make([]types.String, 0, len(attestationType.JqRules))

--- a/internal/provider/data_source_custom_attestation_type.go
+++ b/internal/provider/data_source_custom_attestation_type.go
@@ -30,7 +30,7 @@ type customAttestationTypeDataSourceModel struct {
 	Description types.String         `tfsdk:"description"`
 	Schema      jsontypes.Normalized `tfsdk:"schema"`
 	JqRules     types.List           `tfsdk:"jq_rules"`
-	SummaryJSON jsontypes.Normalized `tfsdk:"summary_json"`
+	Summary     jsontypes.Normalized `tfsdk:"summary"`
 	Archived    types.Bool           `tfsdk:"archived"`
 }
 
@@ -63,7 +63,7 @@ func (d *customAttestationTypeDataSource) Schema(ctx context.Context, req dataso
 				ElementType:         types.StringType,
 				MarkdownDescription: "List of jq expressions that define evaluation rules. All rules must evaluate to `true` for compliance.",
 			},
-			"summary_json": schema.StringAttribute{
+			"summary": schema.StringAttribute{
 				Computed:            true,
 				CustomType:          jsontypes.NormalizedType{},
 				MarkdownDescription: "JSON array of ordered, labelled jq expressions rendered as rows on the attestation detail page in Kosli. Each element is an object with a `name` and an `expression`. Null when the type defines no summary.",
@@ -130,9 +130,9 @@ func (d *customAttestationTypeDataSource) Read(ctx context.Context, req datasour
 	}
 
 	if attestationType.Summary == "" {
-		data.SummaryJSON = jsontypes.NewNormalizedNull()
+		data.Summary = jsontypes.NewNormalizedNull()
 	} else {
-		data.SummaryJSON = jsontypes.NewNormalizedValue(attestationType.Summary)
+		data.Summary = jsontypes.NewNormalizedValue(attestationType.Summary)
 	}
 
 	// Convert jq_rules (API client already transformed from evaluator format)

--- a/internal/provider/data_source_custom_attestation_type_acc_test.go
+++ b/internal/provider/data_source_custom_attestation_type_acc_test.go
@@ -273,3 +273,65 @@ resource "kosli_custom_attestation_type" "derived" {
 }
 `, sourceName, derivedName)
 }
+
+// TestAccCustomAttestationTypeDataSource_summary tests that summary_json is exposed
+// as a computed attribute, and reports null for types that define no summary.
+func TestAccCustomAttestationTypeDataSource_summary(t *testing.T) {
+	withSummary := acctest.RandomWithPrefix("tf-acc-test-ds-summary")
+	withoutSummary := acctest.RandomWithPrefix("tf-acc-test-ds-nosummary")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCustomAttestationTypeDataSourceConfigSummary(withSummary, withoutSummary),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.kosli_custom_attestation_type.with_summary", "summary_json",
+						`[{"expression":".coverage","name":"Coverage"},{"expression":".report_url","name":"Report"}]`),
+					resource.TestCheckResourceAttrPair(
+						"data.kosli_custom_attestation_type.with_summary", "summary_json",
+						"kosli_custom_attestation_type.with_summary", "summary_json"),
+					resource.TestCheckNoResourceAttr("data.kosli_custom_attestation_type.without_summary", "summary_json"),
+				),
+			},
+		},
+	})
+}
+
+// testAccCustomAttestationTypeDataSourceConfigSummary creates one type with a summary
+// and one without, and reads both back through the data source.
+func testAccCustomAttestationTypeDataSourceConfigSummary(withSummary, withoutSummary string) string {
+	return fmt.Sprintf(`
+resource "kosli_custom_attestation_type" "with_summary" {
+  name     = %[1]q
+  jq_rules = [".coverage >= 80"]
+  schema = jsonencode({
+    type = "object"
+    properties = {
+      coverage   = { type = "number" }
+      report_url = { type = "string" }
+    }
+  })
+  summary_json = jsonencode([
+    { name = "Coverage", expression = ".coverage" },
+    { name = "Report", expression = ".report_url" },
+  ])
+}
+
+resource "kosli_custom_attestation_type" "without_summary" {
+  name     = %[2]q
+  jq_rules = [".coverage >= 80"]
+}
+
+data "kosli_custom_attestation_type" "with_summary" {
+  name       = kosli_custom_attestation_type.with_summary.name
+  depends_on = [kosli_custom_attestation_type.with_summary]
+}
+
+data "kosli_custom_attestation_type" "without_summary" {
+  name       = kosli_custom_attestation_type.without_summary.name
+  depends_on = [kosli_custom_attestation_type.without_summary]
+}
+`, withSummary, withoutSummary)
+}

--- a/internal/provider/data_source_custom_attestation_type_acc_test.go
+++ b/internal/provider/data_source_custom_attestation_type_acc_test.go
@@ -274,7 +274,7 @@ resource "kosli_custom_attestation_type" "derived" {
 `, sourceName, derivedName)
 }
 
-// TestAccCustomAttestationTypeDataSource_summary tests that summary_json is exposed
+// TestAccCustomAttestationTypeDataSource_summary tests that summary is exposed
 // as a computed attribute, and reports null for types that define no summary.
 func TestAccCustomAttestationTypeDataSource_summary(t *testing.T) {
 	withSummary := acctest.RandomWithPrefix("tf-acc-test-ds-summary")
@@ -287,12 +287,12 @@ func TestAccCustomAttestationTypeDataSource_summary(t *testing.T) {
 			{
 				Config: testAccCustomAttestationTypeDataSourceConfigSummary(withSummary, withoutSummary),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("data.kosli_custom_attestation_type.with_summary", "summary_json",
+					resource.TestCheckResourceAttr("data.kosli_custom_attestation_type.with_summary", "summary",
 						`[{"expression":".coverage","name":"Coverage"},{"expression":".report_url","name":"Report"}]`),
 					resource.TestCheckResourceAttrPair(
-						"data.kosli_custom_attestation_type.with_summary", "summary_json",
-						"kosli_custom_attestation_type.with_summary", "summary_json"),
-					resource.TestCheckNoResourceAttr("data.kosli_custom_attestation_type.without_summary", "summary_json"),
+						"data.kosli_custom_attestation_type.with_summary", "summary",
+						"kosli_custom_attestation_type.with_summary", "summary"),
+					resource.TestCheckNoResourceAttr("data.kosli_custom_attestation_type.without_summary", "summary"),
 				),
 			},
 		},
@@ -313,7 +313,7 @@ resource "kosli_custom_attestation_type" "with_summary" {
       report_url = { type = "string" }
     }
   })
-  summary_json = jsonencode([
+  summary = jsonencode([
     { name = "Coverage", expression = ".coverage" },
     { name = "Report", expression = ".report_url" },
   ])

--- a/internal/provider/data_source_custom_attestation_type_test.go
+++ b/internal/provider/data_source_custom_attestation_type_test.go
@@ -41,7 +41,7 @@ func TestCustomAttestationTypeDataSource_Schema(t *testing.T) {
 
 	// Verify required attributes exist
 	attrs := resp.Schema.Attributes
-	requiredAttrs := []string{"name", "description", "schema", "jq_rules", "summary_json", "archived"}
+	requiredAttrs := []string{"name", "description", "schema", "jq_rules", "summary", "archived"}
 	for _, attr := range requiredAttrs {
 		if _, exists := attrs[attr]; !exists {
 			t.Errorf("Expected attribute %q to exist in schema", attr)
@@ -72,13 +72,13 @@ func TestCustomAttestationTypeDataSource_Schema(t *testing.T) {
 		t.Error("Expected 'jq_rules' attribute to be computed")
 	}
 
-	// Verify summary_json is computed
-	summaryAttr := attrs["summary_json"]
+	// Verify summary is computed
+	summaryAttr := attrs["summary"]
 	if summaryAttr.IsComputed() == false {
-		t.Error("Expected 'summary_json' attribute to be computed")
+		t.Error("Expected 'summary' attribute to be computed")
 	}
 	if _, ok := summaryAttr.GetType().(jsontypes.NormalizedType); !ok {
-		t.Errorf("Expected 'summary_json' to use jsontypes.NormalizedType, got %T", summaryAttr.GetType())
+		t.Errorf("Expected 'summary' to use jsontypes.NormalizedType, got %T", summaryAttr.GetType())
 	}
 
 	// Verify archived is computed

--- a/internal/provider/data_source_custom_attestation_type_test.go
+++ b/internal/provider/data_source_custom_attestation_type_test.go
@@ -41,7 +41,7 @@ func TestCustomAttestationTypeDataSource_Schema(t *testing.T) {
 
 	// Verify required attributes exist
 	attrs := resp.Schema.Attributes
-	requiredAttrs := []string{"name", "description", "schema", "jq_rules", "archived"}
+	requiredAttrs := []string{"name", "description", "schema", "jq_rules", "summary_json", "archived"}
 	for _, attr := range requiredAttrs {
 		if _, exists := attrs[attr]; !exists {
 			t.Errorf("Expected attribute %q to exist in schema", attr)
@@ -70,6 +70,15 @@ func TestCustomAttestationTypeDataSource_Schema(t *testing.T) {
 	jqRulesAttr := attrs["jq_rules"]
 	if jqRulesAttr.IsComputed() == false {
 		t.Error("Expected 'jq_rules' attribute to be computed")
+	}
+
+	// Verify summary_json is computed
+	summaryAttr := attrs["summary_json"]
+	if summaryAttr.IsComputed() == false {
+		t.Error("Expected 'summary_json' attribute to be computed")
+	}
+	if _, ok := summaryAttr.GetType().(jsontypes.NormalizedType); !ok {
+		t.Errorf("Expected 'summary_json' to use jsontypes.NormalizedType, got %T", summaryAttr.GetType())
 	}
 
 	// Verify archived is computed

--- a/internal/provider/resource_custom_attestation_type.go
+++ b/internal/provider/resource_custom_attestation_type.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -34,6 +35,7 @@ type customAttestationTypeResourceModel struct {
 	Description types.String         `tfsdk:"description"`
 	Schema      jsontypes.Normalized `tfsdk:"schema"`
 	JqRules     types.List           `tfsdk:"jq_rules"`
+	SummaryJSON jsontypes.Normalized `tfsdk:"summary_json"`
 }
 
 // Metadata returns the resource type name.
@@ -68,7 +70,79 @@ func (r *customAttestationTypeResource) Schema(ctx context.Context, req resource
 				Optional:            true,
 				ElementType:         types.StringType,
 			},
+			"summary_json": schema.StringAttribute{
+				MarkdownDescription: "JSON array of ordered, labelled jq expressions rendered as rows on the attestation detail page in Kosli. Each element is an object with a `name` (the row label) and an `expression` (a jq expression evaluated against the attestation data); values that are valid URLs render as links. Can be provided inline using `jsonencode()`/heredoc syntax or loaded from a file using `file()`, so the same JSON can be shared with the Kosli CLI. Example: `jsonencode([{ name = \"Coverage\", expression = \".coverage\" }])`. If omitted, the attestation detail page falls back to showing the jq evaluation results as a pass/fail checklist; removing it from a type that had one clears the summary. Semantic JSON equality is used when reading the value back from Kosli, so your formatting is preserved rather than being rewritten to the API's compact form.",
+				Optional:            true,
+				CustomType:          jsontypes.NormalizedType{},
+			},
 		},
+	}
+}
+
+// toCreateRequest builds the API request from the model. Updates go through the
+// same request type because the API allocates a new version on every POST.
+func (data *customAttestationTypeResourceModel) toCreateRequest(ctx context.Context, diags *diag.Diagnostics) *client.CreateCustomAttestationTypeRequest {
+	// Extract jq_rules from the list if not null
+	var jqRules []string
+	if !data.JqRules.IsNull() {
+		diags.Append(data.JqRules.ElementsAs(ctx, &jqRules, false)...)
+		if diags.HasError() {
+			return nil
+		}
+	}
+
+	// Get schema value, handling null
+	var schemaValue string
+	if !data.Schema.IsNull() {
+		schemaValue = data.Schema.ValueString()
+	}
+
+	// Get summary value, handling null. An omitted summary_json sends no
+	// summary key, which clears any summary on the new version.
+	var summaryValue string
+	if !data.SummaryJSON.IsNull() {
+		summaryValue = data.SummaryJSON.ValueString()
+	}
+
+	return &client.CreateCustomAttestationTypeRequest{
+		Name:        data.Name.ValueString(),
+		Description: data.Description.ValueString(),
+		Schema:      schemaValue,
+		JqRules:     jqRules,
+		Summary:     summaryValue,
+	}
+}
+
+// applyAPIResponse maps an API response onto the model. Empty values are stored
+// as null so that attributes absent from config don't show up as diffs.
+func (data *customAttestationTypeResourceModel) applyAPIResponse(ctx context.Context, attestationType *client.CustomAttestationType, diags *diag.Diagnostics) {
+	if attestationType.Description == "" {
+		data.Description = types.StringNull()
+	} else {
+		data.Description = types.StringValue(attestationType.Description)
+	}
+
+	if attestationType.Schema == "" || attestationType.Schema == "None" {
+		data.Schema = jsontypes.NewNormalizedNull()
+	} else {
+		data.Schema = jsontypes.NewNormalizedValue(attestationType.Schema)
+	}
+
+	if attestationType.Summary == "" {
+		data.SummaryJSON = jsontypes.NewNormalizedNull()
+	} else {
+		data.SummaryJSON = jsontypes.NewNormalizedValue(attestationType.Summary)
+	}
+
+	if len(attestationType.JqRules) == 0 {
+		data.JqRules = types.ListNull(types.StringType)
+	} else {
+		jqRulesList, listDiags := types.ListValueFrom(ctx, types.StringType, attestationType.JqRules)
+		diags.Append(listDiags...)
+		if diags.HasError() {
+			return
+		}
+		data.JqRules = jqRulesList
 	}
 }
 
@@ -100,27 +174,10 @@ func (r *customAttestationTypeResource) Create(ctx context.Context, req resource
 		return
 	}
 
-	// Extract jq_rules from the list if not null
-	var jqRules []string
-	if !data.JqRules.IsNull() {
-		resp.Diagnostics.Append(data.JqRules.ElementsAs(ctx, &jqRules, false)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
-	}
-
-	// Get schema value, handling null
-	var schemaValue string
-	if !data.Schema.IsNull() {
-		schemaValue = data.Schema.ValueString()
-	}
-
-	// Create API request
-	createReq := &client.CreateCustomAttestationTypeRequest{
-		Name:        data.Name.ValueString(),
-		Description: data.Description.ValueString(),
-		Schema:      schemaValue,
-		JqRules:     jqRules,
+	// Build API request
+	createReq := data.toCreateRequest(ctx, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
 	// Call API to create the custom attestation type
@@ -154,30 +211,9 @@ func (r *customAttestationTypeResource) Create(ctx context.Context, req resource
 	}
 
 	// Map API response to Terraform state
-	// Handle empty description as null to avoid inconsistency when not provided in config
-	if attestationType.Description == "" {
-		data.Description = types.StringNull()
-	} else {
-		data.Description = types.StringValue(attestationType.Description)
-	}
-
-	// Handle empty schema as null (similar to description handling)
-	if attestationType.Schema == "" || attestationType.Schema == "None" {
-		data.Schema = jsontypes.NewNormalizedNull()
-	} else {
-		data.Schema = jsontypes.NewNormalizedValue(attestationType.Schema)
-	}
-
-	// Convert jq_rules back to list, handling empty list as null
-	if len(attestationType.JqRules) == 0 {
-		data.JqRules = types.ListNull(types.StringType)
-	} else {
-		jqRulesList, diags := types.ListValueFrom(ctx, types.StringType, attestationType.JqRules)
-		resp.Diagnostics.Append(diags...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
-		data.JqRules = jqRulesList
+	data.applyAPIResponse(ctx, attestationType, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
 	// Save data into Terraform state
@@ -205,30 +241,9 @@ func (r *customAttestationTypeResource) Read(ctx context.Context, req resource.R
 	}
 
 	// Map API response to Terraform state
-	// Handle empty description as null to avoid inconsistency when not provided in config
-	if attestationType.Description == "" {
-		data.Description = types.StringNull()
-	} else {
-		data.Description = types.StringValue(attestationType.Description)
-	}
-
-	// Handle empty schema as null (similar to description handling)
-	if attestationType.Schema == "" || attestationType.Schema == "None" {
-		data.Schema = jsontypes.NewNormalizedNull()
-	} else {
-		data.Schema = jsontypes.NewNormalizedValue(attestationType.Schema)
-	}
-
-	// Convert jq_rules back to list, handling empty list as null
-	if len(attestationType.JqRules) == 0 {
-		data.JqRules = types.ListNull(types.StringType)
-	} else {
-		jqRulesList, diags := types.ListValueFrom(ctx, types.StringType, attestationType.JqRules)
-		resp.Diagnostics.Append(diags...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
-		data.JqRules = jqRulesList
+	data.applyAPIResponse(ctx, attestationType, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
 	// Save updated data into Terraform state
@@ -246,27 +261,10 @@ func (r *customAttestationTypeResource) Update(ctx context.Context, req resource
 		return
 	}
 
-	// Extract jq_rules from the list if not null
-	var jqRules []string
-	if !data.JqRules.IsNull() {
-		resp.Diagnostics.Append(data.JqRules.ElementsAs(ctx, &jqRules, false)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
-	}
-
-	// Get schema value, handling null
-	var schemaValue string
-	if !data.Schema.IsNull() {
-		schemaValue = data.Schema.ValueString()
-	}
-
-	// Create API request (updates create a new version)
-	createReq := &client.CreateCustomAttestationTypeRequest{
-		Name:        data.Name.ValueString(),
-		Description: data.Description.ValueString(),
-		Schema:      schemaValue,
-		JqRules:     jqRules,
+	// Build API request (updates create a new version)
+	createReq := data.toCreateRequest(ctx, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
 	// Call API to create new version
@@ -289,30 +287,9 @@ func (r *customAttestationTypeResource) Update(ctx context.Context, req resource
 	}
 
 	// Map API response to Terraform state
-	// Handle empty description as null to avoid inconsistency when not provided in config
-	if attestationType.Description == "" {
-		data.Description = types.StringNull()
-	} else {
-		data.Description = types.StringValue(attestationType.Description)
-	}
-
-	// Handle empty schema as null (similar to description handling)
-	if attestationType.Schema == "" || attestationType.Schema == "None" {
-		data.Schema = jsontypes.NewNormalizedNull()
-	} else {
-		data.Schema = jsontypes.NewNormalizedValue(attestationType.Schema)
-	}
-
-	// Convert jq_rules back to list, handling empty list as null
-	if len(attestationType.JqRules) == 0 {
-		data.JqRules = types.ListNull(types.StringType)
-	} else {
-		jqRulesList, diags := types.ListValueFrom(ctx, types.StringType, attestationType.JqRules)
-		resp.Diagnostics.Append(diags...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
-		data.JqRules = jqRulesList
+	data.applyAPIResponse(ctx, attestationType, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
 	// Save updated data into Terraform state

--- a/internal/provider/resource_custom_attestation_type.go
+++ b/internal/provider/resource_custom_attestation_type.go
@@ -35,7 +35,7 @@ type customAttestationTypeResourceModel struct {
 	Description types.String         `tfsdk:"description"`
 	Schema      jsontypes.Normalized `tfsdk:"schema"`
 	JqRules     types.List           `tfsdk:"jq_rules"`
-	SummaryJSON jsontypes.Normalized `tfsdk:"summary_json"`
+	Summary     jsontypes.Normalized `tfsdk:"summary"`
 }
 
 // Metadata returns the resource type name.
@@ -70,8 +70,8 @@ func (r *customAttestationTypeResource) Schema(ctx context.Context, req resource
 				Optional:            true,
 				ElementType:         types.StringType,
 			},
-			"summary_json": schema.StringAttribute{
-				MarkdownDescription: "JSON array of ordered, labelled jq expressions rendered as rows on the attestation detail page in Kosli. Each element is an object with a `name` (the row label) and an `expression` (a jq expression evaluated against the attestation data); values that are valid URLs render as links. Can be provided inline using `jsonencode()`/heredoc syntax or loaded from a file using `file()`, so the same JSON can be shared with the Kosli CLI. Example: `jsonencode([{ name = \"Coverage\", expression = \".coverage\" }])`. If omitted, the attestation detail page falls back to showing the jq evaluation results as a pass/fail checklist; removing it from a type that had one clears the summary. Semantic JSON equality is used when reading the value back from Kosli, so your formatting is preserved rather than being rewritten to the API's compact form.",
+			"summary": schema.StringAttribute{
+				MarkdownDescription: "JSON array of ordered, labelled jq expressions rendered as rows on the attestation detail page in Kosli. Each element is an object with a `name` (the row label) and an `expression` (a jq expression evaluated against the attestation data); values that are valid URLs render as links. Can be provided inline using `jsonencode()`/heredoc syntax or loaded from a file using `file()`, so the same JSON can be kept in one place and shared with other tooling. Example: `jsonencode([{ name = \"Coverage\", expression = \".coverage\" }])`. If omitted, the attestation detail page falls back to showing the jq evaluation results as a pass/fail checklist; removing it from a type that had one clears the summary. Semantic JSON equality is used when reading the value back from Kosli, so your formatting is preserved rather than being rewritten to the API's compact form.",
 				Optional:            true,
 				CustomType:          jsontypes.NormalizedType{},
 			},
@@ -97,11 +97,11 @@ func (data *customAttestationTypeResourceModel) toCreateRequest(ctx context.Cont
 		schemaValue = data.Schema.ValueString()
 	}
 
-	// Get summary value, handling null. An omitted summary_json sends no
+	// Get summary value, handling null. When it is null the client sends no
 	// summary key, which clears any summary on the new version.
 	var summaryValue string
-	if !data.SummaryJSON.IsNull() {
-		summaryValue = data.SummaryJSON.ValueString()
+	if !data.Summary.IsNull() {
+		summaryValue = data.Summary.ValueString()
 	}
 
 	return &client.CreateCustomAttestationTypeRequest{
@@ -129,9 +129,9 @@ func (data *customAttestationTypeResourceModel) applyAPIResponse(ctx context.Con
 	}
 
 	if attestationType.Summary == "" {
-		data.SummaryJSON = jsontypes.NewNormalizedNull()
+		data.Summary = jsontypes.NewNormalizedNull()
 	} else {
-		data.SummaryJSON = jsontypes.NewNormalizedValue(attestationType.Summary)
+		data.Summary = jsontypes.NewNormalizedValue(attestationType.Summary)
 	}
 
 	if len(attestationType.JqRules) == 0 {

--- a/internal/provider/resource_custom_attestation_type_acc_test.go
+++ b/internal/provider/resource_custom_attestation_type_acc_test.go
@@ -348,7 +348,7 @@ resource "kosli_custom_attestation_type" "test" {
 }
 
 // TestAccCustomAttestationTypeResource_summary tests creating a resource with
-// summary_json and verifies that the row ordering round-trips.
+// summary and verifies that the row ordering round-trips.
 func TestAccCustomAttestationTypeResource_summary(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "kosli_custom_attestation_type.test"
@@ -361,11 +361,11 @@ func TestAccCustomAttestationTypeResource_summary(t *testing.T) {
 				Config: testAccCustomAttestationTypeResourceConfigSummary(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "summary_json",
+					resource.TestCheckResourceAttr(resourceName, "summary",
 						`[{"expression":".coverage","name":"Coverage"},{"expression":".report_url","name":"Report"}]`),
 				),
 			},
-			// Import verifies that summary_json is populated from the API alone
+			// Import verifies that summary is populated from the API alone
 			{
 				ResourceName:                         resourceName,
 				ImportState:                          true,
@@ -378,7 +378,7 @@ func TestAccCustomAttestationTypeResource_summary(t *testing.T) {
 }
 
 // TestAccCustomAttestationTypeResource_summaryFormatting verifies that a
-// summary_json written as pretty-printed JSON with non-alphabetical key order
+// summary written as pretty-printed JSON with non-alphabetical key order
 // does not produce a perpetual diff against the compact, key-sorted form the API
 // returns. This is what the semantic JSON equality of the attribute type buys:
 // it stops the provider-returned value from clobbering the config as written.
@@ -394,7 +394,7 @@ func TestAccCustomAttestationTypeResource_summaryFormatting(t *testing.T) {
 				Config: testAccCustomAttestationTypeResourceConfigSummaryFormatted(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// The config's own formatting is preserved in state
-					resource.TestMatchResourceAttr(resourceName, "summary_json",
+					resource.TestMatchResourceAttr(resourceName, "summary",
 						regexp.MustCompile(`"name":\s+"Coverage"`)),
 				),
 			},
@@ -409,7 +409,7 @@ func TestAccCustomAttestationTypeResource_summaryFormatting(t *testing.T) {
 }
 
 // TestAccCustomAttestationTypeResource_updateSummary tests adding, changing and
-// removing summary_json on an existing type. Removing it must clear the summary
+// removing summary on an existing type. Removing it must clear the summary
 // on the new version rather than inheriting the previous one.
 func TestAccCustomAttestationTypeResource_updateSummary(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
@@ -423,14 +423,14 @@ func TestAccCustomAttestationTypeResource_updateSummary(t *testing.T) {
 			{
 				Config: testAccCustomAttestationTypeResourceConfig(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckNoResourceAttr(resourceName, "summary_json"),
+					resource.TestCheckNoResourceAttr(resourceName, "summary"),
 				),
 			},
 			// Step 2: Add a summary
 			{
 				Config: testAccCustomAttestationTypeResourceConfigSummary(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "summary_json",
+					resource.TestCheckResourceAttr(resourceName, "summary",
 						`[{"expression":".coverage","name":"Coverage"},{"expression":".report_url","name":"Report"}]`),
 				),
 			},
@@ -438,7 +438,7 @@ func TestAccCustomAttestationTypeResource_updateSummary(t *testing.T) {
 			{
 				Config: testAccCustomAttestationTypeResourceConfigSummaryUpdated(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "summary_json",
+					resource.TestCheckResourceAttr(resourceName, "summary",
 						`[{"expression":".coverage","name":"Line coverage"}]`),
 				),
 			},
@@ -446,14 +446,14 @@ func TestAccCustomAttestationTypeResource_updateSummary(t *testing.T) {
 			{
 				Config: testAccCustomAttestationTypeResourceConfig(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckNoResourceAttr(resourceName, "summary_json"),
+					resource.TestCheckNoResourceAttr(resourceName, "summary"),
 				),
 			},
 		},
 	})
 }
 
-// testAccCustomAttestationTypeResourceConfigSummary returns configuration with summary_json
+// testAccCustomAttestationTypeResourceConfigSummary returns configuration with summary
 func testAccCustomAttestationTypeResourceConfigSummary(name string) string {
 	return fmt.Sprintf(`
 resource "kosli_custom_attestation_type" "test" {
@@ -470,7 +470,7 @@ resource "kosli_custom_attestation_type" "test" {
     }
   })
   jq_rules = [".coverage >= 80"]
-  summary_json = jsonencode([
+  summary = jsonencode([
     { name = "Coverage", expression = ".coverage" },
     { name = "Report", expression = ".report_url" },
   ])
@@ -478,7 +478,7 @@ resource "kosli_custom_attestation_type" "test" {
 `, name)
 }
 
-// testAccCustomAttestationTypeResourceConfigSummaryFormatted writes summary_json
+// testAccCustomAttestationTypeResourceConfigSummaryFormatted writes summary
 // as a pretty-printed heredoc with "name" before "expression", i.e. neither the
 // compact spacing nor the alphabetical key order the API returns.
 func testAccCustomAttestationTypeResourceConfigSummaryFormatted(name string) string {
@@ -497,7 +497,7 @@ resource "kosli_custom_attestation_type" "test" {
     }
   })
   jq_rules = [".coverage >= 80"]
-  summary_json = <<-EOT
+  summary = <<-EOT
     [
       {
         "name": "Coverage",
@@ -531,7 +531,7 @@ resource "kosli_custom_attestation_type" "test" {
     }
   })
   jq_rules = [".coverage >= 80"]
-  summary_json = jsonencode([
+  summary = jsonencode([
     { name = "Line coverage", expression = ".coverage" },
   ])
 }

--- a/internal/provider/resource_custom_attestation_type_acc_test.go
+++ b/internal/provider/resource_custom_attestation_type_acc_test.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -342,6 +343,197 @@ resource "kosli_custom_attestation_type" "test" {
       }
     }
   })
+}
+`, name)
+}
+
+// TestAccCustomAttestationTypeResource_summary tests creating a resource with
+// summary_json and verifies that the row ordering round-trips.
+func TestAccCustomAttestationTypeResource_summary(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "kosli_custom_attestation_type.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCustomAttestationTypeResourceConfigSummary(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "summary_json",
+						`[{"expression":".coverage","name":"Coverage"},{"expression":".report_url","name":"Report"}]`),
+				),
+			},
+			// Import verifies that summary_json is populated from the API alone
+			{
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateId:                        rName,
+				ImportStateVerifyIdentifierAttribute: "name",
+			},
+		},
+	})
+}
+
+// TestAccCustomAttestationTypeResource_summaryFormatting verifies that a
+// summary_json written as pretty-printed JSON with non-alphabetical key order
+// does not produce a perpetual diff against the compact, key-sorted form the API
+// returns. This is what the semantic JSON equality of the attribute type buys:
+// it stops the provider-returned value from clobbering the config as written.
+func TestAccCustomAttestationTypeResource_summaryFormatting(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "kosli_custom_attestation_type.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCustomAttestationTypeResourceConfigSummaryFormatted(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// The config's own formatting is preserved in state
+					resource.TestMatchResourceAttr(resourceName, "summary_json",
+						regexp.MustCompile(`"name":\s+"Coverage"`)),
+				),
+			},
+			// Re-planning the same config must be a no-op, i.e. the compact
+			// form returned by the API did not overwrite the formatted config
+			{
+				Config:   testAccCustomAttestationTypeResourceConfigSummaryFormatted(rName),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+// TestAccCustomAttestationTypeResource_updateSummary tests adding, changing and
+// removing summary_json on an existing type. Removing it must clear the summary
+// on the new version rather than inheriting the previous one.
+func TestAccCustomAttestationTypeResource_updateSummary(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "kosli_custom_attestation_type.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Create without a summary
+			{
+				Config: testAccCustomAttestationTypeResourceConfig(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr(resourceName, "summary_json"),
+				),
+			},
+			// Step 2: Add a summary
+			{
+				Config: testAccCustomAttestationTypeResourceConfigSummary(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "summary_json",
+						`[{"expression":".coverage","name":"Coverage"},{"expression":".report_url","name":"Report"}]`),
+				),
+			},
+			// Step 3: Change the summary rows
+			{
+				Config: testAccCustomAttestationTypeResourceConfigSummaryUpdated(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "summary_json",
+						`[{"expression":".coverage","name":"Line coverage"}]`),
+				),
+			},
+			// Step 4: Remove the summary again
+			{
+				Config: testAccCustomAttestationTypeResourceConfig(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr(resourceName, "summary_json"),
+				),
+			},
+		},
+	})
+}
+
+// testAccCustomAttestationTypeResourceConfigSummary returns configuration with summary_json
+func testAccCustomAttestationTypeResourceConfigSummary(name string) string {
+	return fmt.Sprintf(`
+resource "kosli_custom_attestation_type" "test" {
+  name = %[1]q
+  schema = jsonencode({
+    type = "object"
+    properties = {
+      coverage = {
+        type = "number"
+      }
+      report_url = {
+        type = "string"
+      }
+    }
+  })
+  jq_rules = [".coverage >= 80"]
+  summary_json = jsonencode([
+    { name = "Coverage", expression = ".coverage" },
+    { name = "Report", expression = ".report_url" },
+  ])
+}
+`, name)
+}
+
+// testAccCustomAttestationTypeResourceConfigSummaryFormatted writes summary_json
+// as a pretty-printed heredoc with "name" before "expression", i.e. neither the
+// compact spacing nor the alphabetical key order the API returns.
+func testAccCustomAttestationTypeResourceConfigSummaryFormatted(name string) string {
+	return fmt.Sprintf(`
+resource "kosli_custom_attestation_type" "test" {
+  name = %[1]q
+  schema = jsonencode({
+    type = "object"
+    properties = {
+      coverage = {
+        type = "number"
+      }
+      report_url = {
+        type = "string"
+      }
+    }
+  })
+  jq_rules = [".coverage >= 80"]
+  summary_json = <<-EOT
+    [
+      {
+        "name": "Coverage",
+        "expression": ".coverage"
+      },
+      {
+        "name": "Report",
+        "expression": ".report_url"
+      }
+    ]
+  EOT
+}
+`, name)
+}
+
+// testAccCustomAttestationTypeResourceConfigSummaryUpdated returns configuration
+// with a different set of summary rows
+func testAccCustomAttestationTypeResourceConfigSummaryUpdated(name string) string {
+	return fmt.Sprintf(`
+resource "kosli_custom_attestation_type" "test" {
+  name = %[1]q
+  schema = jsonencode({
+    type = "object"
+    properties = {
+      coverage = {
+        type = "number"
+      }
+      report_url = {
+        type = "string"
+      }
+    }
+  })
+  jq_rules = [".coverage >= 80"]
+  summary_json = jsonencode([
+    { name = "Line coverage", expression = ".coverage" },
+  ])
 }
 `, name)
 }

--- a/internal/provider/resource_custom_attestation_type_test.go
+++ b/internal/provider/resource_custom_attestation_type_test.go
@@ -5,8 +5,10 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/kosli-dev/terraform-provider-kosli/pkg/client"
 )
 
 func TestCustomAttestationTypeResource_Metadata(t *testing.T) {
@@ -41,7 +43,7 @@ func TestCustomAttestationTypeResource_Schema(t *testing.T) {
 
 	// Verify required attributes exist
 	attrs := resp.Schema.Attributes
-	requiredAttrs := []string{"name", "description", "schema", "jq_rules"}
+	requiredAttrs := []string{"name", "description", "schema", "jq_rules", "summary_json"}
 	for _, attr := range requiredAttrs {
 		if _, exists := attrs[attr]; !exists {
 			t.Errorf("Expected attribute %q to exist in schema", attr)
@@ -70,6 +72,16 @@ func TestCustomAttestationTypeResource_Schema(t *testing.T) {
 	jqRulesAttr := attrs["jq_rules"]
 	if jqRulesAttr.IsOptional() == false {
 		t.Error("Expected 'jq_rules' attribute to be optional")
+	}
+
+	// Verify summary_json is optional and uses the JSON custom type so that
+	// formatting differences don't produce perpetual diffs
+	summaryAttr := attrs["summary_json"]
+	if summaryAttr.IsOptional() == false {
+		t.Error("Expected 'summary_json' attribute to be optional")
+	}
+	if _, ok := summaryAttr.GetType().(jsontypes.NormalizedType); !ok {
+		t.Errorf("Expected 'summary_json' to use jsontypes.NormalizedType, got %T", summaryAttr.GetType())
 	}
 }
 
@@ -168,3 +180,95 @@ func TestCustomAttestationTypeResource_Implements(t *testing.T) {
 // - Real resources are created/updated/deleted in a test Kosli organization
 // - The full Terraform lifecycle is exercised
 // - API integration is validated end-to-end
+
+func TestCustomAttestationTypeResource_ToCreateRequest(t *testing.T) {
+	jqRules, diags := types.ListValueFrom(context.TODO(), types.StringType, []string{".coverage >= 80"})
+	if diags.HasError() {
+		t.Fatalf("failed to build jq_rules list: %v", diags)
+	}
+
+	tests := []struct {
+		name            string
+		model           customAttestationTypeResourceModel
+		expectedSummary string
+	}{
+		{
+			name: "summary set",
+			model: customAttestationTypeResourceModel{
+				Name:        types.StringValue("test-type"),
+				Description: types.StringValue("desc"),
+				Schema:      jsontypes.NewNormalizedValue(`{"type":"object"}`),
+				JqRules:     jqRules,
+				SummaryJSON: jsontypes.NewNormalizedValue(`[{"name":"Coverage","expression":".coverage"}]`),
+			},
+			expectedSummary: `[{"name":"Coverage","expression":".coverage"}]`,
+		},
+		{
+			name: "summary null",
+			model: customAttestationTypeResourceModel{
+				Name:        types.StringValue("test-type"),
+				JqRules:     types.ListNull(types.StringType),
+				Schema:      jsontypes.NewNormalizedNull(),
+				SummaryJSON: jsontypes.NewNormalizedNull(),
+			},
+			expectedSummary: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var diags diag.Diagnostics
+			req := tt.model.toCreateRequest(context.TODO(), &diags)
+			if diags.HasError() {
+				t.Fatalf("unexpected diagnostics: %v", diags)
+			}
+			if req.Summary != tt.expectedSummary {
+				t.Errorf("expected Summary %q, got %q", tt.expectedSummary, req.Summary)
+			}
+			if req.Name != "test-type" {
+				t.Errorf("expected Name 'test-type', got %q", req.Name)
+			}
+		})
+	}
+}
+
+func TestCustomAttestationTypeResource_ApplyAPIResponse_Summary(t *testing.T) {
+	tests := []struct {
+		name        string
+		apiSummary  string
+		expectNull  bool
+		expectValue string
+	}{
+		{name: "summary present", apiSummary: `[{"name":"Coverage","expression":".coverage"}]`, expectValue: `[{"name":"Coverage","expression":".coverage"}]`},
+		{name: "summary absent", apiSummary: "", expectNull: true},
+		{name: "summary empty array", apiSummary: "[]", expectValue: "[]"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := &customAttestationTypeResourceModel{Name: types.StringValue("test-type")}
+			var diags diag.Diagnostics
+
+			model.applyAPIResponse(context.TODO(), &client.CustomAttestationType{
+				Name:    "test-type",
+				Summary: tt.apiSummary,
+			}, &diags)
+
+			if diags.HasError() {
+				t.Fatalf("unexpected diagnostics: %v", diags)
+			}
+			if tt.expectNull {
+				if !model.SummaryJSON.IsNull() {
+					t.Errorf("expected SummaryJSON to be null, got %q", model.SummaryJSON.ValueString())
+				}
+				return
+			}
+			if model.SummaryJSON.IsNull() {
+				t.Fatal("expected SummaryJSON to be set, got null")
+			}
+			if model.SummaryJSON.ValueString() != tt.expectValue {
+				t.Errorf("expected SummaryJSON %q, got %q", tt.expectValue, model.SummaryJSON.ValueString())
+			}
+		})
+	}
+}

--- a/internal/provider/resource_custom_attestation_type_test.go
+++ b/internal/provider/resource_custom_attestation_type_test.go
@@ -43,7 +43,7 @@ func TestCustomAttestationTypeResource_Schema(t *testing.T) {
 
 	// Verify required attributes exist
 	attrs := resp.Schema.Attributes
-	requiredAttrs := []string{"name", "description", "schema", "jq_rules", "summary_json"}
+	requiredAttrs := []string{"name", "description", "schema", "jq_rules", "summary"}
 	for _, attr := range requiredAttrs {
 		if _, exists := attrs[attr]; !exists {
 			t.Errorf("Expected attribute %q to exist in schema", attr)
@@ -74,14 +74,14 @@ func TestCustomAttestationTypeResource_Schema(t *testing.T) {
 		t.Error("Expected 'jq_rules' attribute to be optional")
 	}
 
-	// Verify summary_json is optional and uses the JSON custom type so that
+	// Verify summary is optional and uses the JSON custom type so that
 	// formatting differences don't produce perpetual diffs
-	summaryAttr := attrs["summary_json"]
+	summaryAttr := attrs["summary"]
 	if summaryAttr.IsOptional() == false {
-		t.Error("Expected 'summary_json' attribute to be optional")
+		t.Error("Expected 'summary' attribute to be optional")
 	}
 	if _, ok := summaryAttr.GetType().(jsontypes.NormalizedType); !ok {
-		t.Errorf("Expected 'summary_json' to use jsontypes.NormalizedType, got %T", summaryAttr.GetType())
+		t.Errorf("Expected 'summary' to use jsontypes.NormalizedType, got %T", summaryAttr.GetType())
 	}
 }
 
@@ -199,17 +199,17 @@ func TestCustomAttestationTypeResource_ToCreateRequest(t *testing.T) {
 				Description: types.StringValue("desc"),
 				Schema:      jsontypes.NewNormalizedValue(`{"type":"object"}`),
 				JqRules:     jqRules,
-				SummaryJSON: jsontypes.NewNormalizedValue(`[{"name":"Coverage","expression":".coverage"}]`),
+				Summary:     jsontypes.NewNormalizedValue(`[{"name":"Coverage","expression":".coverage"}]`),
 			},
 			expectedSummary: `[{"name":"Coverage","expression":".coverage"}]`,
 		},
 		{
 			name: "summary null",
 			model: customAttestationTypeResourceModel{
-				Name:        types.StringValue("test-type"),
-				JqRules:     types.ListNull(types.StringType),
-				Schema:      jsontypes.NewNormalizedNull(),
-				SummaryJSON: jsontypes.NewNormalizedNull(),
+				Name:    types.StringValue("test-type"),
+				JqRules: types.ListNull(types.StringType),
+				Schema:  jsontypes.NewNormalizedNull(),
+				Summary: jsontypes.NewNormalizedNull(),
 			},
 			expectedSummary: "",
 		},
@@ -258,16 +258,16 @@ func TestCustomAttestationTypeResource_ApplyAPIResponse_Summary(t *testing.T) {
 				t.Fatalf("unexpected diagnostics: %v", diags)
 			}
 			if tt.expectNull {
-				if !model.SummaryJSON.IsNull() {
-					t.Errorf("expected SummaryJSON to be null, got %q", model.SummaryJSON.ValueString())
+				if !model.Summary.IsNull() {
+					t.Errorf("expected Summary to be null, got %q", model.Summary.ValueString())
 				}
 				return
 			}
-			if model.SummaryJSON.IsNull() {
-				t.Fatal("expected SummaryJSON to be set, got null")
+			if model.Summary.IsNull() {
+				t.Fatal("expected Summary to be set, got null")
 			}
-			if model.SummaryJSON.ValueString() != tt.expectValue {
-				t.Errorf("expected SummaryJSON %q, got %q", tt.expectValue, model.SummaryJSON.ValueString())
+			if model.Summary.ValueString() != tt.expectValue {
+				t.Errorf("expected Summary %q, got %q", tt.expectValue, model.Summary.ValueString())
 			}
 		})
 	}

--- a/pkg/client/custom_attestation_types.go
+++ b/pkg/client/custom_attestation_types.go
@@ -18,7 +18,8 @@ type CustomAttestationType struct {
 	Description string    `json:"description"`
 	Schema      string    `json:"-"`        // User-facing (extracted from latest version)
 	JqRules     []string  `json:"-"`        // User-facing (extracted from latest version)
-	Versions    []Version `json:"versions"` // API format (contains schema and evaluator)
+	Summary     string    `json:"-"`        // User-facing JSON array (extracted from latest version)
+	Versions    []Version `json:"versions"` // API format (contains schema, evaluator and summary)
 	Archived    bool      `json:"archived"`
 	Org         string    `json:"org"`
 }
@@ -29,6 +30,7 @@ type Version struct {
 	Timestamp  float64         `json:"timestamp"`
 	TypeSchema json.RawMessage `json:"type_schema"`
 	Evaluator  *Evaluator      `json:"evaluator"`
+	Summary    json.RawMessage `json:"summary"`
 	CreatedBy  string          `json:"created_by"`
 }
 
@@ -44,6 +46,7 @@ type CreateCustomAttestationTypeRequest struct {
 	Description string
 	Schema      string
 	JqRules     []string
+	Summary     string // JSON array of {name, expression} objects; empty means "no summary"
 }
 
 // GetCustomAttestationTypeOptions contains optional parameters for GetCustomAttestationType.
@@ -66,30 +69,52 @@ func (req *CreateCustomAttestationTypeRequest) toAPIFormat() map[string]any {
 		}
 	}
 
+	// Only include summary if provided. Omitting the key clears any summary
+	// carried by the previous version; the API stores null for that version.
+	// The raw JSON is passed through verbatim (json.Marshal validates and
+	// compacts it, and surfaces malformed input as a marshalling error).
+	if req.Summary != "" {
+		data["summary"] = json.RawMessage(req.Summary)
+	}
+
 	return data
 }
 
+// normalizeJSON re-marshals raw JSON to canonical compact form. Empty or JSON
+// null input yields an empty string, so callers can treat "absent" uniformly.
+func normalizeJSON(raw json.RawMessage, field string) (string, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return "", nil
+	}
+
+	var obj any
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return "", fmt.Errorf("invalid JSON in %s: %w", field, err)
+	}
+	normalized, err := json.Marshal(obj)
+	if err != nil {
+		return "", fmt.Errorf("failed to normalize %s JSON: %w", field, err)
+	}
+	return string(normalized), nil
+}
+
 // fromAPIFormat converts API response to user-facing format.
-// Extracts schema and jq_rules from the latest version in the versions array.
+// Extracts schema, jq_rules and summary from the latest version in the versions array.
 func (at *CustomAttestationType) fromAPIFormat() error {
 	if len(at.Versions) > 0 {
 		latestVersion := at.Versions[0]
-		raw := latestVersion.TypeSchema
 
-		if len(raw) == 0 || string(raw) == "null" {
-			at.Schema = ""
-		} else {
-			// Re-marshal to canonical compact JSON
-			var schemaObj any
-			if err := json.Unmarshal(raw, &schemaObj); err != nil {
-				return fmt.Errorf("invalid JSON in type_schema: %w", err)
-			}
-			normalizedJSON, err := json.Marshal(schemaObj)
-			if err != nil {
-				return fmt.Errorf("failed to normalize schema JSON: %w", err)
-			}
-			at.Schema = string(normalizedJSON)
+		schema, err := normalizeJSON(latestVersion.TypeSchema, "type_schema")
+		if err != nil {
+			return err
 		}
+		at.Schema = schema
+
+		summary, err := normalizeJSON(latestVersion.Summary, "summary")
+		if err != nil {
+			return err
+		}
+		at.Summary = summary
 
 		if latestVersion.Evaluator != nil && latestVersion.Evaluator.ContentType == "jq" {
 			at.JqRules = latestVersion.Evaluator.Rules

--- a/pkg/client/custom_attestation_types_test.go
+++ b/pkg/client/custom_attestation_types_test.go
@@ -703,3 +703,158 @@ func TestTransformation_EmptyRules(t *testing.T) {
 		t.Error("expected evaluator to be absent when jq_rules is empty")
 	}
 }
+
+// TestTransformation_ToAPIFormat_Summary tests that summary is passed through
+// verbatim as raw JSON when provided.
+func TestTransformation_ToAPIFormat_Summary(t *testing.T) {
+	req := &CreateCustomAttestationTypeRequest{
+		Name:    "test-type",
+		Summary: `[{"name":"Coverage","expression":".coverage"}]`,
+	}
+
+	result := req.toAPIFormat()
+
+	raw, ok := result["summary"].(json.RawMessage)
+	if !ok {
+		t.Fatalf("expected summary to be json.RawMessage, got %T", result["summary"])
+	}
+	if string(raw) != `[{"name":"Coverage","expression":".coverage"}]` {
+		t.Errorf("summary not passed through verbatim, got %s", raw)
+	}
+
+	// Round-trip through the wire encoding to confirm it lands as a JSON array
+	encoded, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("failed to marshal data_json: %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatalf("failed to unmarshal data_json: %v", err)
+	}
+	summary, ok := decoded["summary"].([]any)
+	if !ok || len(summary) != 1 {
+		t.Fatalf("expected summary to encode as a 1-element array, got %v", decoded["summary"])
+	}
+	entry := summary[0].(map[string]any)
+	if entry["name"] != "Coverage" || entry["expression"] != ".coverage" {
+		t.Errorf("unexpected summary entry: %v", entry)
+	}
+}
+
+// TestTransformation_ToAPIFormat_NoSummary tests that the summary key is omitted
+// when no summary is set. Omitting the key is how a summary gets cleared: the API
+// stores null for the new version.
+func TestTransformation_ToAPIFormat_NoSummary(t *testing.T) {
+	req := &CreateCustomAttestationTypeRequest{
+		Name:    "test-type",
+		JqRules: []string{".age > 21"},
+	}
+
+	result := req.toAPIFormat()
+
+	if _, ok := result["summary"]; ok {
+		t.Error("expected summary to be absent when not set")
+	}
+}
+
+// TestCreateCustomAttestationType_InvalidSummary tests that malformed summary JSON
+// surfaces as an error rather than being sent to the API.
+func TestCreateCustomAttestationType_InvalidSummary(t *testing.T) {
+	req := &CreateCustomAttestationTypeRequest{
+		Name:    "test-type",
+		Summary: `[{"name": broken}]`,
+	}
+
+	if _, _, err := req.MarshalMultipart(); err == nil {
+		t.Fatal("expected an error for malformed summary JSON, got nil")
+	}
+}
+
+// TestTransformation_FromAPIFormat_Summary tests that summary is extracted from the
+// latest version and normalized to canonical compact JSON.
+func TestTransformation_FromAPIFormat_Summary(t *testing.T) {
+	at := &CustomAttestationType{
+		Name: "test-type",
+		Versions: []Version{
+			{
+				Version:    2,
+				TypeSchema: json.RawMessage(`{"type": "object"}`),
+				Summary:    json.RawMessage("[\n  { \"name\": \"Coverage\", \"expression\": \".coverage\" }\n]"),
+			},
+			{
+				Version: 1,
+				Summary: json.RawMessage(`[{"name":"Old","expression":".old"}]`),
+			},
+		},
+	}
+
+	if err := at.fromAPIFormat(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := `[{"expression":".coverage","name":"Coverage"}]`
+	if at.Summary != expected {
+		t.Errorf("expected normalized summary %s, got %s", expected, at.Summary)
+	}
+}
+
+// TestTransformation_FromAPIFormat_SummaryAbsent tests that a version with no summary
+// (the API returns null) yields an empty string rather than the literal "null".
+func TestTransformation_FromAPIFormat_SummaryAbsent(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  json.RawMessage
+	}{
+		{"missing key", nil},
+		{"explicit null", json.RawMessage("null")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			at := &CustomAttestationType{
+				Name:     "test-type",
+				Versions: []Version{{Version: 1, TypeSchema: json.RawMessage(`{"type":"object"}`), Summary: tt.raw}},
+			}
+
+			if err := at.fromAPIFormat(); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if at.Summary != "" {
+				t.Errorf("expected empty summary, got %q", at.Summary)
+			}
+		})
+	}
+}
+
+// TestTransformation_FromAPIFormat_SummaryEmptyList tests that an explicitly empty
+// summary is preserved as an empty JSON array, distinct from "no summary".
+func TestTransformation_FromAPIFormat_SummaryEmptyList(t *testing.T) {
+	at := &CustomAttestationType{
+		Name:     "test-type",
+		Versions: []Version{{Version: 1, Summary: json.RawMessage(`[]`)}},
+	}
+
+	if err := at.fromAPIFormat(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if at.Summary != "[]" {
+		t.Errorf("expected empty summary array to be preserved, got %q", at.Summary)
+	}
+}
+
+// TestTransformation_FromAPIFormat_InvalidSummary tests that malformed summary JSON
+// from the API surfaces as an error.
+func TestTransformation_FromAPIFormat_InvalidSummary(t *testing.T) {
+	at := &CustomAttestationType{
+		Name:     "test-type",
+		Versions: []Version{{Version: 1, Summary: json.RawMessage(`[{"name":`)}},
+	}
+
+	err := at.fromAPIFormat()
+	if err == nil {
+		t.Fatal("expected an error for malformed summary JSON, got nil")
+	}
+	if !strings.Contains(err.Error(), "summary") {
+		t.Errorf("expected error to mention summary, got %v", err)
+	}
+}


### PR DESCRIPTION
Closes #239

Adds an optional `summary` attribute to `kosli_custom_attestation_type` (resource and data source): a JSON array of ordered, labelled jq expressions that Kosli renders as rows on the attestation detail page, with URL values rendered as links.

```hcl
resource "kosli_custom_attestation_type" "security_scan" {
  name     = "security-scan"
  schema   = file("${path.module}/schemas/security-scan.json")
  jq_rules = [".critical_count == 0"]

  summary = jsonencode([
    { name = "Critical", expression = ".critical_count" },
    { name = "Report", expression = ".report_url" },
  ])
}
```

Single JSON-string attribute named to match the sibling `schema`, and mirroring how it already works, so the same blob can be kept in a file and shared with other tooling. This is the option the issue proposed over nested blocks.

## API verification

#239 was labelled `blocked` pending the API change. I probed production before writing any code and `summary` is live:

- `POST /api/v2/custom-attestation-types/{org}` accepts `summary` in the `data_json` part, and it round-trips through `GET` as a new `summary` key on the version object.
- Server-side validation is strict: must be a list, `name` and `expression` both required, extra keys rejected, and expressions are compiled as jq and rejected if invalid. Duplicate names are allowed.
- **Clearing works by omission**, which was the open question in the issue. Posting a new version without the key stores `null`; posting `summary: []` stores an empty list. Update needs no explicit empty list.

Probe types were created in a personal org and archived afterwards. The `blocked` label on #239 can come off.

## Changes

- **`pkg/client`**: `Summary` on `CustomAttestationType`, `CreateCustomAttestationTypeRequest`, and `Version`. Raw JSON passes through verbatim on write; malformed input surfaces as a marshalling error rather than reaching the API. Extracted a `normalizeJSON` helper now shared by `schema` and `summary`, so both normalise to canonical compact JSON on read.
- **Resource**: `summary` as an optional `jsontypes.Normalized`, threaded through Create/Read/Update.
- **Data source**: `summary` computed.
- **Refactor**: request-building and response-mapping pulled out of the resource's Create/Read/Update into `toCreateRequest`/`applyAPIResponse`. That logic was triplicated and adding a fourth field to three copies invites drift.
- Examples (including a `file()`-based one with real companion JSON), regenerated docs, example README.

## Two things worth a reviewer's attention

**This fixes a pre-existing bug.** The data source set `schema` to an empty string for types defined without one, which the JSON attribute type rejects as malformed JSON. Any `data "kosli_custom_attestation_type"` pointing at a schema-less type failed with *"A string value was provided that is not valid JSON"*. The new data source test hit it, so it is fixed here: it now reports null, matching the resource.

**A doc claim was corrected rather than copied.** The existing `schema` description says formatting differences are ignored via semantic equality. My first acceptance test asserted that for `summary` and failed: reformatting the config does produce a diff, because for Optional non-Computed attributes the plan value comes straight from config and Terraform core diffs it literally. What semantic equality actually prevents is the API's compact, key-sorted response overwriting formatted config, which would otherwise be a perpetual diff. The test now covers that real behaviour and `summary`'s description is worded accordingly. The `schema` description carries the same overstated claim; left alone as out of scope.

## Testing

- 7 new client unit tests (round-trip, omission, empty list, null, malformed input both directions).
- 4 new provider unit tests covering `toCreateRequest` and `applyAPIResponse`, plus schema assertions.
- 4 new acceptance tests: create with summary and import, formatting stability, add/change/remove lifecycle, and data source exposure including the null case.
- Full `TestAccCustomAttestationType` suite green against production (16/16), so no regressions on the existing resource or data source.
- `make fmt`, `make vet`, `make lint` (0 issues), `make docs`, and `terraform validate` on both touched examples.

Client package coverage is 87.3%.

## Review follow-up

Renamed `summary_json` to `summary` per review, matching the sibling `schema` attribute, which is also a JSON string with no `_json` suffix. Doing it now avoids a deprecation cycle, since the attribute has not shipped. Full acceptance suite re-run green after the rename (16/16).

Also dropped the claim that the JSON can be shared with the Kosli CLI. The CLI has no summary flag as of v2.36.6, so the description now refers to other tooling generally.
